### PR TITLE
Ignore openshift/client-go as it doesn't tag versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,4 @@ updates:
     ignore:
     - dependency-name: "k8s.io/*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    - dependency-name: "github.com/openshift/client-go"


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
