### PR TITLE
Fix the operator after pipelinesascode rename…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is the repository of a *proof-of-concept* of OpenShift Operator based of th
 - [x] GitHub workflows
 - [x] Import `OpenShiftPipelinesAsCode` in here
 - [x] Rename `OpenShiftPipelinesAsCode` to `PipelinesAsCode`
+- [ ] Support watching/converting `OpenShiftPipelinesAsCode` to `PipelinesAsCode`
 - [ ] `Makefile`
 - [ ] Automated/scripted import payload (copy from tektoncd/operator)
 - [ ] Automated/scripted import `tektoncd/operator` CRDs

--- a/config/300-operator_v1alpha1_pipelinesascode_crd.yaml
+++ b/config/300-operator_v1alpha1_pipelinesascode_crd.yaml
@@ -15,19 +15,18 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: openshiftpipelinesascodes.operator.tekton.dev
+  name: pipelinesascodes.operator.openshift-pipelines.org
   labels:
     version: "devel"
     operator.tekton.dev/release: "devel"
 spec:
-  group: operator.tekton.dev
+  group: operator.openshift-pipelines.org
   names:
-    kind: OpenShiftPipelinesAsCode
-    listKind: OpenShiftPipelinesAsCodeList
-    plural: openshiftpipelinesascodes
-    singular: openshiftpipelinesascode
+    kind: PipelinesAsCode
+    listKind: PipelinesAsCodeList
+    plural: pipelinesascodes
+    singular: pipelinesascode
     shortNames:
-    - opac
     - pac
   preserveUnknownFields: false
   scope: Cluster
@@ -50,5 +49,5 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        description: Schema for the OpenShiftPipelinesAsCode API
+        description: Schema for the PipelinesAsCode API
         x-kubernetes-preserve-unknown-fields: true

--- a/config/operator.yaml
+++ b/config/operator.yaml
@@ -39,7 +39,7 @@ spec:
         image: ko://github.com/openshift-pipelines/operator/cmd/operator
         args:
         - "-controllers"
-        - "tektonconfig,tektonpipeline,tektontrigger,tektonhub,tektonchain,tektonaddon,openshiftpipelinesascode"
+        - "tektonconfig,tektonpipeline,tektontrigger,tektonhub,tektonchain,tektonaddon,pipelinesascode"
         - "-unique-process-name"
         - "tekton-operator-lifecycle"
         imagePullPolicy: Always

--- a/config/role.yaml
+++ b/config/role.yaml
@@ -219,6 +219,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - operator.openshift-pipelines.org
+  resources:
+  - '*'
+  verbs:
+  - delete
+  - deletecollection
+  - create
+  - patch
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - tekton.dev
   - triggers.tekton.dev
   - operator.tekton.dev

--- a/pkg/reconciler/openshiftplatform/config.go
+++ b/pkg/reconciler/openshiftplatform/config.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	ControllerTektonAddon              platform.ControllerName = "tektonaddon"
-	ControllerPipelinesAsCode platform.ControllerName = "openshiftpipelinesascode"
+	ControllerPipelinesAsCode          platform.ControllerName = "pipelinesascode"
 	PlatformNameOpenShift              string                  = "openshift"
 )
 

--- a/pkg/reconciler/pipelinesascode/controller.go
+++ b/pkg/reconciler/pipelinesascode/controller.go
@@ -20,8 +20,9 @@ import (
 	"context"
 
 	"github.com/openshift-pipelines/operator/pkg/apis/operator/v1alpha1"
+	// tektonoperatorv1alpha1 "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	tektonoperatorclient "github.com/tektoncd/operator/pkg/client/injection/client"
-	pacInformer "github.com/openshift-pipelines/operator/pkg/client/injection/informers/operator/v1alpha1/pipelinesascode"
+	pacInformer "github.com/openshift-pipelines/operator/pkg/client/injection/informers/operator/v1alpha1/pipelinesascode"	
 	tektonInstallerinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektoninstallerset"
 	tektonPipelineinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonpipeline"
 	pacreconciler "github.com/openshift-pipelines/operator/pkg/client/injection/reconciler/operator/v1alpha1/pipelinesascode"

--- a/pkg/reconciler/tektonconfig/controller.go
+++ b/pkg/reconciler/tektonconfig/controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	openshiftpipelinesascodeinformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/openshiftpipelinesascode"
+	pipelinesascodeinformer "github.com/openshift-pipelines/operator/pkg/client/injection/informers/operator/v1alpha1/pipelinesascode"
 	tektonAddoninformer "github.com/tektoncd/operator/pkg/client/injection/informers/operator/v1alpha1/tektonaddon"
 	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig"
 	"k8s.io/client-go/tools/cache"
@@ -36,7 +36,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		FilterFunc: controller.FilterController(&v1alpha1.TektonConfig{}),
 		Handler:    controller.HandleAll(ctrl.EnqueueControllerOf),
 	})
-	openshiftpipelinesascodeinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	pipelinesascodeinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterController(&v1alpha1.TektonConfig{}),
 		Handler:    controller.HandleAll(ctrl.EnqueueControllerOf),
 	})

--- a/pkg/reconciler/tektonconfig/extension/pipelinesascode_test.go
+++ b/pkg/reconciler/tektonconfig/extension/pipelinesascode_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"testing"
 
-	op "github.com/tektoncd/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
+	op "github.com/openshift-pipelines/operator/pkg/client/clientset/versioned/typed/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/reconciler/shared/tektonconfig/pipeline"
 
-	"github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	"github.com/tektoncd/operator/pkg/client/injection/client/fake"
+	tektonoperatorv1alpha1 "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
+	"github.com/openshift-pipelines/operator/pkg/apis/operator/v1alpha1"
+	"github.com/openshift-pipelines/operator/pkg/client/injection/client/fake"
 	util "github.com/tektoncd/operator/pkg/reconciler/common/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ts "knative.dev/pkg/reconciler/testing"
@@ -39,27 +40,27 @@ func TestEnsureOpenShiftPipelinesAsCodeExists(t *testing.T) {
 
 	tConfig.SetDefaults(ctx)
 	// first invocation should create instance as it is non-existent and return RECONCILE_AGAIN_ERR
-	_, err := EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
-	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+	_, err := EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().PipelinesAsCodes(), tConfig)
+	util.AssertEqual(t, err, tektonoperatorv1alpha1.RECONCILE_AGAIN_ERR)
 
 	// during second invocation instance exists but waiting on dependencies (pipeline, triggers)
 	// hence returns DEPENDENCY_UPGRADE_PENDING_ERR
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
-	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().PipelinesAsCodes(), tConfig)
+	util.AssertEqual(t, err, tektonoperatorv1alpha1.RECONCILE_AGAIN_ERR)
 
 	// mark the instance ready
-	markOPACReady(t, ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes())
+	markOPACReady(t, ctx, c.OperatorV1alpha1().PipelinesAsCodes())
 
 	// next invocation should return nil error as the instance is ready
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().PipelinesAsCodes(), tConfig)
 	util.AssertEqual(t, err, nil)
 
 	// test update propagation from tektonConfig
 	tConfig.Spec.TargetNamespace = "foobar"
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
-	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().PipelinesAsCodes(), tConfig)
+	util.AssertEqual(t, err, tektonoperatorv1alpha1.RECONCILE_AGAIN_ERR)
 
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().PipelinesAsCodes(), tConfig)
 	util.AssertEqual(t, err, nil)
 }
 
@@ -70,28 +71,28 @@ func TestEnsureOpenShiftPipelinesAsCodeCRNotExists(t *testing.T) {
 	t.Setenv("PLATFORM", "openshift")
 
 	// when no instance exists, nil error is returned immediately
-	err := EnsureOpenShiftPipelinesAsCodeCRNotExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes())
+	err := EnsureOpenShiftPipelinesAsCodeCRNotExists(ctx, c.OperatorV1alpha1().PipelinesAsCodes())
 	util.AssertEqual(t, err, nil)
 
 	// create an instance for testing other cases
 	tConfig := pipeline.GetTektonConfig()
 	tConfig.SetDefaults(ctx)
-	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes(), tConfig)
-	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+	_, err = EnsureOpenShiftPipelinesAsCodeExists(ctx, c.OperatorV1alpha1().PipelinesAsCodes(), tConfig)
+	util.AssertEqual(t, err, tektonoperatorv1alpha1.RECONCILE_AGAIN_ERR)
 
 	// when an instance exists the first invoacation should make the delete API call and
 	// return RECONCILE_AGAI_ERROR. So that the deletion can be confirmed in a subsequent invocation
-	err = EnsureOpenShiftPipelinesAsCodeCRNotExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes())
-	util.AssertEqual(t, err, v1alpha1.RECONCILE_AGAIN_ERR)
+	err = EnsureOpenShiftPipelinesAsCodeCRNotExists(ctx, c.OperatorV1alpha1().PipelinesAsCodes())
+	util.AssertEqual(t, err, tektonoperatorv1alpha1.RECONCILE_AGAIN_ERR)
 
 	// when the instance is completely removed from a cluster, the function should return nil error
-	err = EnsureOpenShiftPipelinesAsCodeCRNotExists(ctx, c.OperatorV1alpha1().OpenShiftPipelinesAsCodes())
+	err = EnsureOpenShiftPipelinesAsCodeCRNotExists(ctx, c.OperatorV1alpha1().PipelinesAsCodes())
 	util.AssertEqual(t, err, nil)
 }
 
-func markOPACReady(t *testing.T, ctx context.Context, c op.OpenShiftPipelinesAsCodeInterface) {
+func markOPACReady(t *testing.T, ctx context.Context, c op.PipelinesAsCodeInterface) {
 	t.Helper()
-	opac, err := c.Get(ctx, v1alpha1.OpenShiftPipelinesAsCodeName, metav1.GetOptions{})
+	opac, err := c.Get(ctx, v1alpha1.PipelinesAsCodeName, metav1.GetOptions{})
 	util.AssertEqual(t, err, nil)
 	opac.Status.MarkDependenciesInstalled()
 	opac.Status.MarkPreReconcilerComplete()


### PR DESCRIPTION
Add the old CRD back (as it's still watched by upstream code — to be removed at some point) and fix rbac to let the operator watch the new one.

Some code also needed to change to create the correct type.