### PR TITLE
Updating buildah sha which has fix for sbom_cyclonedx.valid EC

### DIFF
--- a/.tekton/docker-build-ta.yaml
+++ b/.tekton/docker-build-ta.yaml
@@ -214,7 +214,7 @@ spec:
       - name: name
         value: buildah-remote-oci-ta
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:6e17d2199e839b633cf841a640ddf9ec0fbc8b0a8a4e8c7596ec60ed47eb52e9
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:e8f69168ea59919288c7a943347bd68184f762d405ead56f4a5e0fcc851115c6
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
Got below EC failure on pac-downstream 
```
Results:
✕ [Violation] sbom_cyclonedx.valid
  ImageRef: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pac-downstream-next/webhook@sha256:b60d2582d2b4d147b5af1a7245b25672873f70b07f045dc03c3eb230147542d7
  Reason: CycloneDX SBOM at index 0 is not valid: $schema: $schema must be one of the following:
  "http://cyclonedx.org/schema/bom-1.5.schema.json"
  Title: Valid
  Description: Check the CycloneDX SBOM has the expected format. It verifies the CycloneDX SBOM matches the 1.5 version of the
  schema. To exclude this rule add "sbom_cyclonedx.valid" to the `exclude` section of the policy configuration.
  Solution: Make sure the build process produces a valid CycloneDX SBOM.
```
The reason for the cause is the buildah task is generating CycloneDX 1.6

The solution for the above EC failure is

* update to the buildah task to latest revision, which has reverted back to CycloneDX 1.5
* We need to wait until Saturday, when Mintmaker will update tasks for you automatically

To unblock EC failure on PAC adding this changes and later anyhow MintMaker will autoupdate
