### PR TITLE
Adding SINGLE_COMPONENT param in index IntegrationTestScenarios

### DIFF
--- a/.konflux/1.18/tests-index-4-15.yaml
+++ b/.konflux/1.18/tests-index-4-15.yaml
@@ -13,6 +13,8 @@ spec:
       value: tekton-ecosystem-tenant/tekton-ecosystem-tenant-indexes
     - name: TIMEOUT
       value: "15m0s"
+    - name: SINGLE_COMPONENT
+      value: "true"
   resolverRef:
     params:
       - name: url

--- a/.konflux/1.18/tests-index-4-16.yaml
+++ b/.konflux/1.18/tests-index-4-16.yaml
@@ -13,6 +13,8 @@ spec:
       value: tekton-ecosystem-tenant/tekton-ecosystem-tenant-indexes
     - name: TIMEOUT
       value: "15m0s"
+    - name: SINGLE_COMPONENT
+      value: "true"
   resolverRef:
     params:
       - name: url

--- a/.konflux/1.18/tests-index-4-17.yaml
+++ b/.konflux/1.18/tests-index-4-17.yaml
@@ -13,6 +13,8 @@ spec:
       value: tekton-ecosystem-tenant/tekton-ecosystem-tenant-indexes
     - name: TIMEOUT
       value: "15m0s"
+    - name: SINGLE_COMPONENT
+      value: "true"
   resolverRef:
     params:
       - name: url

--- a/.konflux/main/tests-index-4-15.yaml
+++ b/.konflux/main/tests-index-4-15.yaml
@@ -13,6 +13,8 @@ spec:
       value: tekton-ecosystem-tenant/tekton-ecosystem-tenant-indexes
     - name: TIMEOUT
       value: "15m0s"
+    - name: SINGLE_COMPONENT
+      value: "true"
   resolverRef:
     params:
       - name: url

--- a/.konflux/main/tests-index-4-16.yaml
+++ b/.konflux/main/tests-index-4-16.yaml
@@ -13,6 +13,8 @@ spec:
       value: tekton-ecosystem-tenant/tekton-ecosystem-tenant-indexes
     - name: TIMEOUT
       value: "15m0s"
+    - name: SINGLE_COMPONENT
+      value: "true"
   resolverRef:
     params:
       - name: url

--- a/.konflux/main/tests-index-4-17.yaml
+++ b/.konflux/main/tests-index-4-17.yaml
@@ -13,6 +13,8 @@ spec:
       value: tekton-ecosystem-tenant/tekton-ecosystem-tenant-indexes
     - name: TIMEOUT
       value: "15m0s"
+    - name: SINGLE_COMPONENT
+      value: "true"
   resolverRef:
     params:
       - name: url

--- a/.konflux/next/tests-index-4-15.yaml
+++ b/.konflux/next/tests-index-4-15.yaml
@@ -13,6 +13,8 @@ spec:
       value: tekton-ecosystem-tenant/tekton-ecosystem-tenant-indexes
     - name: TIMEOUT
       value: "15m0s"
+    - name: SINGLE_COMPONENT
+      value: "true"
   resolverRef:
     params:
       - name: url

--- a/.konflux/next/tests-index-4-16.yaml
+++ b/.konflux/next/tests-index-4-16.yaml
@@ -13,6 +13,8 @@ spec:
       value: tekton-ecosystem-tenant/tekton-ecosystem-tenant-indexes
     - name: TIMEOUT
       value: "15m0s"
+    - name: SINGLE_COMPONENT
+      value: "true"
   resolverRef:
     params:
       - name: url

--- a/.konflux/next/tests-index-4-17.yaml
+++ b/.konflux/next/tests-index-4-17.yaml
@@ -13,6 +13,8 @@ spec:
       value: tekton-ecosystem-tenant/tekton-ecosystem-tenant-indexes
     - name: TIMEOUT
       value: "15m0s"
+    - name: SINGLE_COMPONENT
+      value: "true"
   resolverRef:
     params:
       - name: url


### PR DESCRIPTION
Adding `SINGLE_COMPONENT=true` will assure that other component's failure will not impact the component being tested