### PR TITLE
Adding Schedule to index-render-template-next

### DIFF
--- a/.github/workflows/index-render-template-next.yaml
+++ b/.github/workflows/index-render-template-next.yaml
@@ -2,6 +2,8 @@ name: index-render-template-next
 
 on:
   workflow_dispatch: {}
+  schedule:
+    - cron: "0 2 * * *" # At 2AM everyday
   push:
     branch:
       - "next"

--- a/.konflux/main/tests-e2e-tektoncd-pipelines.yaml
+++ b/.konflux/main/tests-e2e-tektoncd-pipelines.yaml
@@ -5,8 +5,12 @@ metadata:
 spec:
   application: operator-main
   contexts:
-    - description: Application testing
-      name: component_operator-main-bundle
+    - description: E2e testing for operator-main-index-4-15
+      name: component_operator-main-index-4-15
+    - description: E2e testing for operator-main-index-4-16
+      name: component_operator-main-index-4-16
+    - description: E2e testing for operator-main-index-4-17
+      name: component_operator-main-index-4-17
   resolverRef:
     params:
       - name: url


### PR DESCRIPTION
Update e2e IntegrationTestScenario to run with index images

[Adding Schedule to index-render-template-next](https://github.com/openshift-pipelines/operator/commit/3d77e22ea9f54e508bb7fcdc0ae5e0d139b100b4)