### PR TITLE
Update Tekton CEL for Index Images.

### DIFF
--- a/.tekton/operator-next-index-4-15-pull-request.yaml
+++ b/.tekton/operator-next-index-4-15-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next" &&
       (".tekton/operator-next-index-4-15-push.yaml".pathChanged() ||
       ".tekton/operator-next-index-4-15-pull-request.yaml".pathChanged() ||
-      ".konflux/olm-catalog/index/v4.15/***".pathChanged() ||
+      ".konflux/olm-catalog/index/v4.15/catalog/***".pathChanged() ||
       ".tekton/fbc-build.yaml".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/operator-next-index-4-15-push.yaml
+++ b/.tekton/operator-next-index-4-15-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next" &&
       (".tekton/operator-next-index-4-15-push.yaml".pathChanged() ||
       ".tekton/operator-next-index-4-15-pull-request.yaml".pathChanged() ||
-      ".konflux/olm-catalog/index/v4.15/***".pathChanged() ||
+      ".konflux/olm-catalog/index/v4.15/catalog/***".pathChanged() ||
       ".tekton/fbc-build.yaml".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/operator-next-index-4-16-pull-request.yaml
+++ b/.tekton/operator-next-index-4-16-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next" &&
       (".tekton/operator-next-index-4-16-push.yaml".pathChanged() ||
       ".tekton/operator-next-index-4-16-pull-request.yaml".pathChanged() ||
-      ".konflux/olm-catalog/index/v4.16/***".pathChanged() ||
+      ".konflux/olm-catalog/index/v4.16/catalog/***".pathChanged() ||
       ".tekton/fbc-build.yaml".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/operator-next-index-4-16-push.yaml
+++ b/.tekton/operator-next-index-4-16-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next" &&
       (".tekton/operator-next-index-4-16-push.yaml".pathChanged() ||
       ".tekton/operator-next-index-4-16-pull-request.yaml".pathChanged() ||
-      ".konflux/olm-catalog/index/v4.16/***".pathChanged() ||
+      ".konflux/olm-catalog/index/v4.16/catalog/***".pathChanged() ||
       ".tekton/fbc-build.yaml".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/operator-next-index-4-17-pull-request.yaml
+++ b/.tekton/operator-next-index-4-17-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "next" &&
       (".tekton/operator-next-index-4-17-push.yaml".pathChanged() ||
       ".tekton/operator-next-index-4-17-pull-request.yaml".pathChanged() ||
-      ".konflux/olm-catalog/index/v4.17/***".pathChanged() ||
+      ".konflux/olm-catalog/index/v4.17/catalog/***".pathChanged() ||
       ".tekton/fbc-build.yaml".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/operator-next-index-4-17-push.yaml
+++ b/.tekton/operator-next-index-4-17-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "next" &&
       (".tekton/operator-next-index-4-17-push.yaml".pathChanged() ||
       ".tekton/operator-next-index-4-17-pull-request.yaml".pathChanged() ||
-      ".konflux/olm-catalog/index/v4.17/***".pathChanged() ||
+      ".konflux/olm-catalog/index/v4.17/catalog/***".pathChanged() ||
       ".tekton/fbc-build.yaml".pathChanged())
   creationTimestamp: null
   labels:


### PR DESCRIPTION
We need not generate the index images when catalog-template.json is updated. in this case index image will just use the old version of bundle which is updated in catalog.json by render template workflow. We need to generate index images only when catalog.json is updated.