### PR TITLE
Update size for s390x

### DIFF
--- a/.tekton/docker-build-ta.yaml
+++ b/.tekton/docker-build-ta.yaml
@@ -12,7 +12,7 @@ spec:
   - default:
     - linux-m2xlarge/arm64
     - linux/ppc64le
-    - linux/s390x
+    - linux-m2xlarge/s390x
     - linux/x86_64
     description: List of platforms to build the container images on. The available
       set of values is determined by the configuration of the multi-platform-controller.


### PR DESCRIPTION
while building image for tektoncd-hub its failing for s390x architecture with below error

```
npm warn deprecated core-js@2.6.12: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
npm error code ENOMEM
npm error syscall spawn
npm error errno -12
npm error spawn ENOMEM

npm error A complete log of this run can be found in: /opt/app-root/src/.npm/_logs/2025-02-13T11_43_25_831Z-debug-0.log
subprocess exited with status 244
subprocess exited with status 244
Error: building at STEP "RUN . /cachi2/cachi2.env &&     npm clean-install --legacy-peer-deps &&     npm run build": exit status 244
```

So updating the memory size of s390x so that hub ui can be success