### PR TITLE
Removed ecosystem-cert-preflight-checks from build pipleine to fix EC issue on bundle image

### DIFF
--- a/.tekton/docker-build-ta.yaml
+++ b/.tekton/docker-build-ta.yaml
@@ -346,26 +346,6 @@ spec:
       operator: in
       values:
       - "false"
-  - name: ecosystem-cert-preflight-checks
-    params:
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: ecosystem-cert-preflight-checks
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:2ad615f9b8141ed2e0b060ebda366ce43cf55a9dd7c98e2d93970ff328dca8b2
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
   - name: sast-snyk-check
     params:
     - name: image-digest


### PR DESCRIPTION


Discussion Thread : https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1739485390067169?thread_ts=1739484196.992639&cid=C04PZ7H0VA8

Issue
```
Our Conforma result is failing with:
```✕ [Violation] test.no_skipped_tests
  ImageRef: quay.io/redhat-user-workloads/gatekeeper-tenant/gatekeeper-operator-3-17/gatekeeper-operator-bundle-3-17@sha256:4093954aa6c90e17cf02aa71be842ba56e6cb87b2a5cee1bb475632f93901e8d
  Reason: The Task "ecosystem-cert-preflight-checks" from the build Pipeline reports a test was skipped
```