### PR TITLE
Add fbc-fips-check task to fbc-build pipeline

### DIFF
--- a/.tekton/fbc-build.yaml
+++ b/.tekton/fbc-build.yaml
@@ -309,6 +309,30 @@ spec:
       operator: in
       values:
       - "false"
+  - name: fbc-fips-check-oci-ta
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: fbc-fips-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:d7ef84eec629003d39b275a1c2ad86e03047164f09766fecba1a412fbbebf583
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
   workspaces:
   - name: git-auth
     optional: true


### PR DESCRIPTION
While executing release pipeline for index images got below error
```
Results:
✕ [Violation] tasks.required_tasks_found
  ImageRef: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/operator-1-18-index-4-15-application/index-4.15@sha256:c4352378e3a37c1c728096c3358ef09b58cd09d9831604c5b8d316d3cb0853f4
  Reason: One of "fbc-fips-check", "fbc-fips-check-oci-ta" tasks is missing
  Title: All required tasks were included in the pipeline
  Description: Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add one or
  more of "tasks.required_tasks_found:fbc-fips-check", "tasks.required_tasks_found:fbc-fips-check-oci-ta" to the `exclude` section
  of the policy configuration.
  Solution: Make sure all required tasks are in the build pipeline. The required task list is contained as
  xref:ec-cli:ROOT:configuration.adoc#_data_sources[data] under the key 'required-tasks'.

```

So adding new task to handle this