### PR TITLE
[1.18]Add ImageDigestMirrorSet to solve Could not find Image mirror set

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageDigestMirrorSet
+metadata:
+  name: openshift-pipelines-mirror-set
+spec:
+  imageDigestMirrors:
+    - mirrors:
+        - quay.io/openshift-pipeline/pipelines-operator-bundle
+      source: registry.stage.redhat.io/openshift-pipelines/pipelines-operator-bundle


### PR DESCRIPTION
The task execution failing with below error

```
{"result":"FAILURE","timestamp":"2025-03-01T09:38:28+00:00","note":"Task operator-1-18-index-4-15-on-push-x657l-fbc-fips-check-oci-ta failed: Could not render unreleased bundle image: registry.stage.redhat.io/openshift-pipelines/pipelines-operator-bundle@sha256:148e898847e2620a62c1e80e83c6367219de64972e199e996b010107e07f9c33. Make sure the image is accessible or a mirror is provided for the same in images-mirror-set.yaml","namespace":"default","successes":0,"failures":1,"warnings":0}
```
so as per the doc from here https://github.com/konflux-ci/build-definitions/blob/main/task/fbc-fips-check-oci-ta/0.1/README.md added  ImageDigestMirrorSet under `.tekton`