### PR TITLE
update render template to make it work with 4.17 and later version

### DIFF
--- a/.github/workflows/index-render-template-1-18.yaml
+++ b/.github/workflows/index-render-template-1-18.yaml
@@ -85,7 +85,13 @@ jobs:
         # Update catalog-template
         sed -i "s%5.0.5-[0-9]\+%${BUNDLE_VERSION}%g" .konflux/olm-catalog/index/${{matrix.version}}/catalog-template.json
 
-        opm alpha render-template basic .konflux/olm-catalog/index/${{matrix.version}}/catalog-template.json > .konflux/olm-catalog/index/${{matrix.version}}/catalog/openshift-pipelines-operator-rh/catalog.json
+        # as per this doc https://github.com/konflux-ci/olm-operator-konflux-sample/blob/main/docs/konflux-onboarding.md#create-the-fbc-in-the-git-repository
+        # Starting with OCP 4.17 we need the --migrate-level=bundle-object-to-csv-metadata flag. For rendering to older versions of OCP.
+        if (( $(echo "${{ matrix.version }} >= 4.17" | bc -l) )); then
+          opm alpha render-template basic .konflux/olm-catalog/index/${{matrix.version}}/catalog-template.json [--migrate-level=bundle-object-to-csv-metadata] > .konflux/olm-catalog/index/${{matrix.version}}/catalog/openshift-pipelines-operator-rh/catalog.json
+        else
+          opm alpha render-template basic .konflux/olm-catalog/index/${{matrix.version}}/catalog-template.json > .konflux/olm-catalog/index/${{matrix.version}}/catalog/openshift-pipelines-operator-rh/catalog.json
+        fi
     - name: Commit new changes
       run: |
         git config user.name openshift-pipelines-bot


### PR DESCRIPTION

Got below errors while building index images for 4.17 and 4.18

EC error

```
✕ [Violation] test.no_erred_tests
  ImageRef: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/operator-1-18-index-4-15-application/index-4.15@sha256:48b58177fa6aee7fbe8d04fcfb6a4936a866a9f2ea18f8b1f71b8a1a0e525415
  Reason: The Task "validate-fbc" from the build Pipeline reports a test erred
  Title: No tests erred
  Description: Produce a violation if any tests have their result set to "ERROR". The result type is configurable by the
  "erred_tests_results" key in the rule data. To exclude this rule add "test.no_erred_tests:validate-fbc" to the `exclude` section
  of the policy configuration.
  Solution: There is a test that erred. Make sure that any task in the build pipeline with a result named 'TEST_OUTPUT' does not
  err. More information about the test should be available in the logs for the build Pipeline.
```

```
While building index images
getting this error in validate-fbc task
 /tekton/scripts/script-1-7p2bq: line 237: note: unbound variable
{"result":"ERROR","timestamp":"2025-03-05T11:44:06+00:00","note":"Unexpected error: Script errored at command: ERROR_OUTPUT=$(make_result_json -r FAILURE -f $failure_num -s $((check_num - failure_num)) -t \"$note\").","namespace":"default","successes":0,"failures":0,"warnings":0} 
which is causing EC failure

I also observed below error
 step-extract-and-validate

/tmp/image-content /var/workdir/extract-and-validate
OPM_BINARY: '/extracted_base_img/usr/bin/registry/opm'
Rendering catalog fragment.
false
false
!FAILURE! - olm.bundle.object bundle properties are not permitted in a FBC fragment for OCP version 4.17. Fragments must move to olm.csv.metadata bundle metadata.
!FAILURE! - every olm.bundle object in the fragment must have a corresponding olm.csv.metadata bundle property  
```

Followed this doc :https://github.com/konflux-ci/olm-operator-konflux-sample/blob/main/docs/konflux-onboarding.md#create-the-fbc-in-the-git-repository
 to overcome the issue