### PR TITLE
Add entries for olm.channel with supported versions

### DIFF
--- a/.konflux/olm-catalog/index/v4.15/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.15/catalog-template.json
@@ -22,6 +22,50 @@
       "schema": "olm.channel"
     },
     {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.17.1",
+          "skipRange": ">=1.17.0 <1.17.1"
+        }
+      ],
+      "name": "pipelines-1.17",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },
+    {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.16.3",
+          "skipRange": ">=1.16.0 <1.16.3"
+        }
+      ],
+      "name": "pipelines-1.16",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },
+    {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.15.2",
+          "skipRange": ">=1.14.0 <1.15.2"
+        }
+      ],
+      "name": "pipelines-1.15",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },
+    {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.14.5",
+          "skipRange": ">=1.13.0 <1.14.5"
+        }
+      ],
+      "name": "pipelines-1.14",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },
+    {
       "schema": "olm.bundle",
       "image": "registry.stage.redhat.io/openshift-pipelines/pipelines-operator-bundle@sha256:dce73ec906405982fd7c4dbb5df67d833315e33d91d556df934a8e363bc9845a"
     }

--- a/.konflux/olm-catalog/index/v4.16/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.16/catalog-template.json
@@ -22,6 +22,50 @@
       "schema": "olm.channel"
     },
     {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.17.1",
+          "skipRange": ">=1.17.0 <1.17.1"
+        }
+      ],
+      "name": "pipelines-1.17",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },
+    {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.16.3",
+          "skipRange": ">=1.16.0 <1.16.3"
+        }
+      ],
+      "name": "pipelines-1.16",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },
+    {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.15.2",
+          "skipRange": ">=1.14.0 <1.15.2"
+        }
+      ],
+      "name": "pipelines-1.15",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },
+    {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.14.5",
+          "skipRange": ">=1.13.0 <1.14.5"
+        }
+      ],
+      "name": "pipelines-1.14",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },    
+    {
       "schema": "olm.bundle",
       "image": "registry.stage.redhat.io/openshift-pipelines/pipelines-operator-bundle@sha256:dce73ec906405982fd7c4dbb5df67d833315e33d91d556df934a8e363bc9845a"
     }

--- a/.konflux/olm-catalog/index/v4.17/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.17/catalog-template.json
@@ -22,6 +22,28 @@
       "schema": "olm.channel"
     },
     {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.17.1",
+          "skipRange": ">=1.17.0 <1.17.1"
+        }
+      ],
+      "name": "pipelines-1.17",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },
+    {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.16.3",
+          "skipRange": ">=1.16.0 <1.16.3"
+        }
+      ],
+      "name": "pipelines-1.16",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },   
+    {
       "schema": "olm.bundle",
       "image": "registry.stage.redhat.io/openshift-pipelines/pipelines-operator-bundle@sha256:dce73ec906405982fd7c4dbb5df67d833315e33d91d556df934a8e363bc9845a"
     }

--- a/.konflux/olm-catalog/index/v4.18/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.18/catalog-template.json
@@ -22,6 +22,17 @@
       "schema": "olm.channel"
     },
     {
+      "entries": [
+        {
+          "name": "openshift-pipelines-operator-rh.v1.17.1",
+          "skipRange": ">=1.17.0 <1.17.1"
+        }
+      ],
+      "name": "pipelines-1.17",
+      "package": "openshift-pipelines-operator-rh",
+      "schema": "olm.channel"
+    },    
+    {
       "schema": "olm.bundle",
       "image": "registry.stage.redhat.io/openshift-pipelines/pipelines-operator-bundle@sha256:dce73ec906405982fd7c4dbb5df67d833315e33d91d556df934a8e363bc9845a"
     }


### PR DESCRIPTION
The task fbc-target-index-pruning-check failing with below error

For the channels latest, pipelines-1.14, 1.15, 1.16 and 1.17 its says FAILURE FBC fragment prunes entire openshift-pipelines-operator-rh

Slack discussion : https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1741176168019019