### PR TITLE
Update Dockerfile to add extra labels

### DIFF
--- a/.konflux/olm-catalog/bundle/Dockerfile
+++ b/.konflux/olm-catalog/bundle/Dockerfile
@@ -27,6 +27,8 @@ LABEL \
       com.redhat.delivery.backport=false \
       io.openshift.tags="pipelines,tekton,openshift" \
       vendor="Red Hat, Inc." \
-      distribution-scope="public"
+      distribution-scope="public" \
+      release="Openshift Pipelines 1.14.6" \
+      url="https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9-minimal/images/9.4-1227.1725849298"
 
 USER 65532


### PR DESCRIPTION
Adding these labels to solve below EC issues
```
Results:
✕ [Violation] labels.required_labels
  ImageRef: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/1-14/operator-bundle-rhel8@sha256:5cbbcc8608b516dd13181c1f331ef5339f126f1b7331ec3e6f6af991b824c0c0
  Reason: The required "release" label is missing. Label description: Release Number for this version.
  Title: Required labels
  Description: Check the image for the presence of labels that are required. Use the rule data `required_labels` key to set the
  list of labels to check, or the `fbc_required_labels` key for fbc images. To exclude this rule add
  "labels.required_labels:release" to the `exclude` section of the policy configuration.
  Solution: Update the image build process to set the required labels.

✕ [Violation] labels.required_labels
  ImageRef: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/1-14/operator-bundle-rhel8@sha256:5cbbcc8608b516dd13181c1f331ef5339f126f1b7331ec3e6f6af991b824c0c0
  Reason: The required "url" label is missing. Label description: A URL where the user can find more information about the image.
  Title: Required labels
  Description: Check the image for the presence of labels that are required. Use the rule data `required_labels` key to set the
  list of labels to check, or the `fbc_required_labels` key for fbc images. To exclude this rule add "labels.required_labels:url"
  to the `exclude` section of the policy configuration.
  Solution: Update the image build process to set the required labels.

```