### PR TITLE
Rollback remote-resolvers image

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -13,7 +13,7 @@ images:
   - name: IMAGE_PIPELINES_WEBHOOK
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/next/pipeline-webhook-rhel9@sha256:95385904a3dd47b028299b7b922e480c6cf98d14c8166c03bce0eb04eb14ee8a
   - name: IMAGE_PIPELINES_CONTROLLER # should be RESOLVERS instead
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/next/pipeline-resolvers-rhel9@sha256:374170dbe957f52ab32ab8f054aaca167b0de0d685a49eb0e59d95920b2d0111
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/next/pipeline-resolvers-rhel9@sha256:2f8c76a2f2fb8ecd55e41aade368b266a071945a0860e4cc577db9226c40069a
   - name: IMAGE_PIPELINES_TEKTON_EVENTS_CONTROLLER
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/next/pipeline-events-rhel9@sha256:e7dacc5c5c3bb912fa7c7f982cd58fad5d84a64e5d3d72f56fc0fcbe15868bd6
   - name: IMAGE_PIPELINES_ARG__ENTRYPOINT_IMAGE


### PR DESCRIPTION
DO NOT MERGE until confirmed that this is the correct way to create a new index build for the `next` release channel