### PR TITLE
Remove ppitonak from OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,9 @@ reviewers:
 - vdemeester
 - jkandasa
 - savitaashture
-- ppitonak
 - openshift-pipelines-bot
 approvers:
 - vdemeester
 - jkandasa
 - savitaashture
-- ppitonak
 - openshift-pipelines-bot


### PR DESCRIPTION
I am automatically set as a reviewer on PRs even though I am no longer on team.