### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for operator-1-19-proxy

### DIFF
--- a/.konflux/dockerfiles/proxy.Dockerfile
+++ b/.konflux/dockerfiles/proxy.Dockerfile
@@ -24,6 +24,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-operator-proxy-rhel9-container" \
       name="openshift-pipelines/pipelines-operator-proxy-rhel9" \
       version="1.19.0" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.19::el9" \
       summary="Red Hat OpenShift Pipelines Operator Proxy" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Operator Proxy" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
