### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for operator-1-18-webhook

### DIFF
--- a/.konflux/dockerfiles/webhook.Dockerfile
+++ b/.konflux/dockerfiles/webhook.Dockerfile
@@ -28,6 +28,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-operator-webhook-rhel9-container" \
       name="openshift-pipelines/pipelines-operator-webhook-rhel9" \
       version="1.18.0" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.18::el9" \
       summary="Red Hat OpenShift Pipelines Operator Webhook" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Operator Webhook" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
