### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for operator-1-18-bundle

### DIFF
--- a/.konflux/olm-catalog/bundle/Dockerfile
+++ b/.konflux/olm-catalog/bundle/Dockerfile
@@ -16,8 +16,9 @@ LABEL operators.operatorframework.io.bundle.channels.v1="latest,pipelines-1.18"
 
 LABEL \
       com.redhat.component="openshift-pipelines-operator-bundle-container" \
-      name="openshift-pipelines/pipelines-operator-bundle-container" \
+      name="openshift-pipelines/pipelines-operator-bundle" \
       version="1.18.1" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.18::el9" \
       summary="Red Hat OpenShift Pipelines Operator Bundle" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Operator Bundle" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
