### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for operator-1-16-bundle

### DIFF
--- a/.konflux/olm-catalog/bundle/Dockerfile
+++ b/.konflux/olm-catalog/bundle/Dockerfile
@@ -16,7 +16,8 @@ LABEL operators.operatorframework.io.bundle.channels.v1="pipelines-1.16"
 
 LABEL \
       com.redhat.component="openshift-pipelines-operator-bundle-container" \
-      name="openshift-pipelines/pipelines-operator-bundle-container" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.16::el8" \
+      name="openshift-pipelines/pipelines-operator-bundle" \
       version="1.16.4" \
       summary="Red Hat OpenShift Pipelines Operator Bundle" \
       maintainer="pipelines-extcomm@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
