### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for operator-1-15-operator

### DIFF
--- a/.konflux/dockerfiles/operator.Dockerfile
+++ b/.konflux/dockerfiles/operator.Dockerfile
@@ -27,6 +27,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-rhel8-operator-container" \
       name="openshift-pipelines/pipelines-rhel8-operator" \
       version="1.15.3" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.15::el8" \
       summary="Red Hat OpenShift Pipelines Operator" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
