### PR TITLE
chore: include additional VCS metadata in build labels

### DIFF
--- a/.tekton/docker-build-ta.yaml
+++ b/.tekton/docker-build-ta.yaml
@@ -26,6 +26,10 @@ spec:
     name: git-url
     type: string
   - default: ""
+    description: Upstream source Repository URL
+    name: upstream-git-url
+    type: string
+  - default: ""
     description: Revision of the Source Repository
     name: revision
     type: string
@@ -33,7 +37,7 @@ spec:
     name: output-image
     type: string
   - default: .
-    description: Path to the source code of an application's component from where
+    description: Path to the source code of an applications component from where
       to build image.
     name: path-context
     type: string
@@ -142,6 +146,35 @@ spec:
     workspaces:
     - name: basic-auth
       workspace: git-auth
+  - name: extract-upstream-info
+    taskSpec:
+      results:
+      - name: upstream-vcs-ref
+      steps:
+      - name: use-trusted-artifact
+        image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:8391272c4e5011120e9e7fee2c1f339e9405366110bf239dadcbc21e953ce099
+        args:
+        - use
+        - $(tasks.clone-repository.results.SOURCE_ARTIFACT)=/var/workdir/source
+      - image: registry.access.redhat.com/ubi9/ubi
+        workingDir: /var/workdir/source
+        script: |
+          #!/usr/bin/env bash
+          echo -n $(cat head 2>/dev/null || echo -n "") | tee $(results.upstream-vcs-ref.path)
+      stepTemplate:
+        volumeMounts:
+        - mountPath: /var/workdir
+          name: workdir
+      volumes:
+      - name: workdir
+        emptyDir: {}
+    runAfter:
+    - clone-repository
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
   - name: prefetch-dependencies
     params:
     - name: input
@@ -209,8 +242,16 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
       value: $(params.build-image-index)
+    - name: LABELS
+      value:
+        - "io.openshift.build.commit.id=$(tasks.clone-repository.results.commit)"
+        - "io.openshift.build.commit.url=$(params.git-url)/commit/$(tasks.clone-repository.results.commit)"
+        - "io.openshift.build.source-location=$(params.git-url)"
+        - "upstream-vcs-ref=$(tasks.extract-upstream-info.results.upstream-vcs-ref)"
+        - "upstream-vcs-location=$(params.upstream-git-url)"
     runAfter:
     - prefetch-dependencies
+    - extract-upstream-info
     taskRef:
       params:
       - name: name


### PR DESCRIPTION
Add the following labels to the container image:
        - `io.openshift.build.commit.id` - same as existing label `vcs-ref`
        - `io.openshift.build.commit.url` - Link to commit in downstream repo. For example ` "io.openshift.build.commit.url": "https://github.com/openshift-pipelines/tektoncd-pipeline/commit/fd973842a04bfcf0039265faec6eb407a10b4974"`
        - `io.openshift.build.source-location` - Link to downstream source repository
        - `upstream-vcs-ref` - Optional. Upstream commit SHA which downstream build is based on. Sourced from the `/head` file, if present.
        - `upstream-vcs-location` - Optional. Link to upstream repository, if provided by the pipelinerun as a param.
        
For `upstream-vcs-location` to work a PR must be made to the hack repository to supply the corresponding pipeline param `upstream-git-url` in the component pipelinerun templates.

See tests for this automation [here](https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/tekton-ecosystem-tenant/applications/openshift-pipelines-core-next/pipelineruns/tektoncd-pipeline-next-controller-on-pull-request-z4c96):
```
 $ skopeo inspect docker://quay.io/redhat-user-workloads/tekton-ecosystem-tenant/next/pipeline-controller-rhel9:on-pr-fd973842a04bfcf0039265faec6eb407a10b4974-linux-x86-64 | jq .Labels
{
  "architecture": "x86_64",
  "build-date": "2025-09-26T19:48:42",
  "com.redhat.component": "openshift-pipelines-controller-rhel9-container",
  "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
  "description": "Red Hat OpenShift Pipelines Controller",
  "distribution-scope": "public",
  "io.buildah.version": "1.39.0-dev",
  "io.k8s.description": "Red Hat OpenShift Pipelines Controller",
  "io.k8s.display-name": "Red Hat OpenShift Pipelines Controller",
  "io.openshift.build.commit.id": "fd973842a04bfcf0039265faec6eb407a10b4974",
  "io.openshift.build.commit.url": "https://github.com/openshift-pipelines/tektoncd-pipeline/commit/fd973842a04bfcf0039265faec6eb407a10b4974",
  "io.openshift.build.source-locationhttps://github.com/openshift-pipelines/tektoncd-pipeline": "",
  "io.openshift.expose-services": "",
  "io.openshift.tags": "pipelines,tekton,openshift",
  "maintainer": "pipelines-extcomm@redhat.com",
  "name": "openshift-pipelines/pipelines-controller-rhel9",
  "org.opencontainers.image.revision": "0c20ee48321f5d64135f6208d1332c0b032df6c3",
  "quay.expires-after": "5d",
  "release": "1758184547",
  "summary": "Red Hat OpenShift Pipelines Controller",
  "upstream-vcs-location": "",
  "upstream-vcs-ref": "43c0bb99fa768ff711ad92445c43179b93232877\\n",
  "url": "https://catalog.redhat.com/en/search?searchType=containers",
  "vcs-ref": "fd973842a04bfcf0039265faec6eb407a10b4974",
  "vcs-type": "git",
  "vendor": "Red Hat, Inc.",
  "version": "pipeline-next"
}
```