### PR TITLE
fix: Add serviceAccountName to index pipeline taskRunTemplate

### DIFF
--- a/.tekton/operator-1-15-index-4-14-pull-request.yaml
+++ b/.tekton/operator-1-15-index-4-14-pull-request.yaml
@@ -37,7 +37,8 @@ spec:
       - linux/x86_64
   pipelineRef:
     name: fbc-build
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-1-15-index-4-14
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/operator-1-15-index-4-14-push.yaml
+++ b/.tekton/operator-1-15-index-4-14-push.yaml
@@ -32,7 +32,8 @@ spec:
     value: .konflux/olm-catalog/index/v4.14/Dockerfile.catalog
   pipelineRef:
     name: fbc-build
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-1-15-index-4-14
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/operator-1-15-index-4-15-pull-request.yaml
+++ b/.tekton/operator-1-15-index-4-15-pull-request.yaml
@@ -37,7 +37,8 @@ spec:
       - linux/x86_64
   pipelineRef:
     name: fbc-build
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-1-15-index-4-15
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/operator-1-15-index-4-15-push.yaml
+++ b/.tekton/operator-1-15-index-4-15-push.yaml
@@ -32,7 +32,8 @@ spec:
     value: .konflux/olm-catalog/index/v4.15/Dockerfile.catalog
   pipelineRef:
     name: fbc-build
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-1-15-index-4-15
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/operator-1-15-index-4-16-pull-request.yaml
+++ b/.tekton/operator-1-15-index-4-16-pull-request.yaml
@@ -37,7 +37,8 @@ spec:
       - linux/x86_64
   pipelineRef:
     name: fbc-build
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-1-15-index-4-16
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/operator-1-15-index-4-16-push.yaml
+++ b/.tekton/operator-1-15-index-4-16-push.yaml
@@ -32,7 +32,8 @@ spec:
     value: .konflux/olm-catalog/index/v4.16/Dockerfile.catalog
   pipelineRef:
     name: fbc-build
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-1-15-index-4-16
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/operator-1-15-index-4-17-pull-request.yaml
+++ b/.tekton/operator-1-15-index-4-17-pull-request.yaml
@@ -37,7 +37,8 @@ spec:
       - linux/x86_64
   pipelineRef:
     name: fbc-build
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-1-15-index-4-17
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/operator-1-15-index-4-17-push.yaml
+++ b/.tekton/operator-1-15-index-4-17-push.yaml
@@ -32,7 +32,8 @@ spec:
     value: .konflux/olm-catalog/index/v4.17/Dockerfile.catalog
   pipelineRef:
     name: fbc-build
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-1-15-index-4-17
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/operator-1-15-index-4-18-pull-request.yaml
+++ b/.tekton/operator-1-15-index-4-18-pull-request.yaml
@@ -37,7 +37,8 @@ spec:
       - linux/x86_64
   pipelineRef:
     name: fbc-build
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-1-15-index-4-18
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/operator-1-15-index-4-18-push.yaml
+++ b/.tekton/operator-1-15-index-4-18-push.yaml
@@ -32,7 +32,8 @@ spec:
     value: .konflux/olm-catalog/index/v4.18/Dockerfile.catalog
   pipelineRef:
     name: fbc-build
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-operator-1-15-index-4-18
   workspaces:
   - name: workspace
     volumeClaimTemplate:


### PR DESCRIPTION
## Summary

Fixes the index Konflux PR/push pipelines that were failing due to missing `serviceAccountName` in `taskRunTemplate`.

## Problem

All index pipelines for OSP 1.15 were failing immediately (~25s) with:
```
Unauthorized error, wrong registry credentials provided
```

**Root cause:** The `taskRunTemplate: {}` was empty, so no service account was providing registry credentials for the `git-clone-oci-ta` task's OCI artifact caching.

## Fix

Added `serviceAccountName` to all 12 index pipeline files:

| OCP Version | Pull Request | Push |
|-------------|--------------|------|
| 4.12 | ✅ | ✅ |
| 4.14 | ✅ | ✅ |
| 4.15 | ✅ | ✅ |
| 4.16 | ✅ | ✅ |
| 4.17 | ✅ | ✅ |
| 4.18 | ✅ | ✅ |

**Before:**
```yaml
taskRunTemplate: {}
```

**After:**
```yaml
taskRunTemplate:
  serviceAccountName: build-pipeline-operator-1-15-index-4-XX
```

## Impact

After this PR is merged:
1. The existing catalog PRs (#14207-#14212) should pass CI on retrigger
2. Dev release can proceed with index image builds

## Related

- Fixes ISS-005 (index PR Konflux pipelines failing)
- Unblocks OSP 1.15.4 dev release