### PR TITLE
chore(1.15.4): bump version to 1.15.4

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -1,6 +1,6 @@
 versions:
-  current: 1.15.3
-  previous: 1.15.2
+  current: 1.15.4
+  previous: 1.15.3
   previous_range: 1.14.0
   channel: pipelines-1.15
   openshift:


### PR DESCRIPTION
## Summary
- Bump current version from 1.15.3 to 1.15.4
- Bump previous version from 1.15.2 to 1.15.3

## Purpose
Prepare for 1.15.4 patch release with CVE fixes:
- jwt-go v4.5.2 (CVE-2024-51744)
- x/crypto v0.35.0 (CVE-2024-45337)
- oauth2 v0.27.0 (CVE-2025-22868)

This version update is required before running `operator-update-images` workflow to get fresh component images with the new version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)