### PR TITLE
fix(1.15.4): Add v1.15.4 bundle to catalog-template.json

### DIFF
--- a/.konflux/olm-catalog/index/v4.12/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.12/catalog-template.json
@@ -278,6 +278,11 @@
           "name": "openshift-pipelines-operator-rh.v1.15.3",
           "replaces": "openshift-pipelines-operator-rh.v1.15.2",
           "skipRange": ">=1.14.0 <1.15.3"
+        },
+        {
+          "name": "openshift-pipelines-operator-rh.v1.15.4",
+          "replaces": "openshift-pipelines-operator-rh.v1.15.3",
+          "skipRange": ">=1.14.0 <1.15.4"
         }
       ],
       "name": "pipelines-1.15",
@@ -383,6 +388,11 @@
       "schema": "olm.bundle",
       "name": "openshift-pipelines-operator-rh.v1.15.3",
       "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:0ba1efe8f9fce499ec4259ea39eef5e0f0536185e84c1e84b766ae3efa2d9b37"
+    },
+    {
+      "schema": "olm.bundle",
+      "name": "openshift-pipelines-operator-rh.v1.15.4",
+      "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:e9eb98ac08453a63c534fe6f6ba75bc6989e9d171770aab6e971d1c4617c7535"
     }
   ]
 }

--- a/.konflux/olm-catalog/index/v4.14/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.14/catalog-template.json
@@ -240,6 +240,11 @@
           "name": "openshift-pipelines-operator-rh.v1.15.3",
           "replaces": "openshift-pipelines-operator-rh.v1.15.2",
           "skipRange": ">=1.14.0 <1.15.3"
+        },
+        {
+          "name": "openshift-pipelines-operator-rh.v1.15.4",
+          "replaces": "openshift-pipelines-operator-rh.v1.15.3",
+          "skipRange": ">=1.14.0 <1.15.4"
         }
       ],
       "name": "pipelines-1.15",
@@ -330,6 +335,11 @@
       "schema": "olm.bundle",
       "name": "openshift-pipelines-operator-rh.v1.15.3",
       "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:0ba1efe8f9fce499ec4259ea39eef5e0f0536185e84c1e84b766ae3efa2d9b37"
+    },
+    {
+      "schema": "olm.bundle",
+      "name": "openshift-pipelines-operator-rh.v1.15.4",
+      "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:e9eb98ac08453a63c534fe6f6ba75bc6989e9d171770aab6e971d1c4617c7535"
     }
   ]
 }

--- a/.konflux/olm-catalog/index/v4.15/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.15/catalog-template.json
@@ -182,6 +182,11 @@
           "name": "openshift-pipelines-operator-rh.v1.15.3",
           "replaces": "openshift-pipelines-operator-rh.v1.15.2",
           "skipRange": ">=1.14.0 <1.15.3"
+        },
+        {
+          "name": "openshift-pipelines-operator-rh.v1.15.4",
+          "replaces": "openshift-pipelines-operator-rh.v1.15.3",
+          "skipRange": ">=1.14.0 <1.15.4"
         }
       ],
       "name": "pipelines-1.15",
@@ -426,6 +431,11 @@
       "schema": "olm.bundle",
       "name": "openshift-pipelines-operator-rh.v1.15.3",
       "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:0ba1efe8f9fce499ec4259ea39eef5e0f0536185e84c1e84b766ae3efa2d9b37"
+    },
+    {
+      "schema": "olm.bundle",
+      "name": "openshift-pipelines-operator-rh.v1.15.4",
+      "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:e9eb98ac08453a63c534fe6f6ba75bc6989e9d171770aab6e971d1c4617c7535"
     }
   ]
 }

--- a/.konflux/olm-catalog/index/v4.16/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.16/catalog-template.json
@@ -182,6 +182,11 @@
           "name": "openshift-pipelines-operator-rh.v1.15.3",
           "replaces": "openshift-pipelines-operator-rh.v1.15.2",
           "skipRange": ">=1.14.0 <1.15.3"
+        },
+        {
+          "name": "openshift-pipelines-operator-rh.v1.15.4",
+          "replaces": "openshift-pipelines-operator-rh.v1.15.3",
+          "skipRange": ">=1.14.0 <1.15.4"
         }
       ],
       "name": "pipelines-1.15",
@@ -426,6 +431,11 @@
       "schema": "olm.bundle",
       "name": "openshift-pipelines-operator-rh.v1.15.3",
       "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:0ba1efe8f9fce499ec4259ea39eef5e0f0536185e84c1e84b766ae3efa2d9b37"
+    },
+    {
+      "schema": "olm.bundle",
+      "name": "openshift-pipelines-operator-rh.v1.15.4",
+      "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:e9eb98ac08453a63c534fe6f6ba75bc6989e9d171770aab6e971d1c4617c7535"
     }
   ]
 }

--- a/.konflux/olm-catalog/index/v4.17/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.17/catalog-template.json
@@ -90,6 +90,11 @@
           "name": "openshift-pipelines-operator-rh.v1.15.3",
           "replaces": "openshift-pipelines-operator-rh.v1.15.2",
           "skipRange": ">=1.14.0 <1.15.3"
+        },
+        {
+          "name": "openshift-pipelines-operator-rh.v1.15.4",
+          "replaces": "openshift-pipelines-operator-rh.v1.15.3",
+          "skipRange": ">=1.14.0 <1.15.4"
         }
       ],
       "name": "pipelines-1.15",
@@ -241,6 +246,11 @@
       "schema": "olm.bundle",
       "name": "openshift-pipelines-operator-rh.v1.15.3",
       "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:0ba1efe8f9fce499ec4259ea39eef5e0f0536185e84c1e84b766ae3efa2d9b37"
+    },
+    {
+      "schema": "olm.bundle",
+      "name": "openshift-pipelines-operator-rh.v1.15.4",
+      "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:e9eb98ac08453a63c534fe6f6ba75bc6989e9d171770aab6e971d1c4617c7535"
     }
   ]
 }

--- a/.konflux/olm-catalog/index/v4.18/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.18/catalog-template.json
@@ -90,6 +90,11 @@
           "name": "openshift-pipelines-operator-rh.v1.15.3",
           "replaces": "openshift-pipelines-operator-rh.v1.15.2",
           "skipRange": ">=1.14.0 <1.15.3"
+        },
+        {
+          "name": "openshift-pipelines-operator-rh.v1.15.4",
+          "replaces": "openshift-pipelines-operator-rh.v1.15.3",
+          "skipRange": ">=1.14.0 <1.15.4"
         }
       ],
       "name": "pipelines-1.15",
@@ -240,6 +245,11 @@
     {
       "schema": "olm.bundle",
       "name": "openshift-pipelines-operator-rh.v1.15.3",
+      "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:e9eb98ac08453a63c534fe6f6ba75bc6989e9d171770aab6e971d1c4617c7535"
+    },
+    {
+      "schema": "olm.bundle",
+      "name": "openshift-pipelines-operator-rh.v1.15.4",
       "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:e9eb98ac08453a63c534fe6f6ba75bc6989e9d171770aab6e971d1c4617c7535"
     }
   ]

--- a/hack/index-render-template.sh
+++ b/hack/index-render-template.sh
@@ -2,7 +2,7 @@
 
 # Update BUNDLE_NAME for each release according to the corresponding 'name' value specified in the catalog-template.json file.
 # ex: for 1.19 it will be openshift-pipelines-operator-rh.v1.19.0, for 1.17.2 it will be openshift-pipelines-operator-rh.v1.17.2
-BUNDLE_NAME=openshift-pipelines-operator-rh.v1.15.3
+BUNDLE_NAME=openshift-pipelines-operator-rh.v1.15.4
 
 # Update images from project.yaml to "generated" files
 VERSION=${1:-"v4.18"}


### PR DESCRIPTION
## Summary

The index-render-template workflow was failing because v1.15.4 was never properly added to the catalog templates. This PR adds the missing entries.

### Root Cause

The `index-render-template.sh` script only updates the image SHA for an **existing** bundle entry - it does not add new versions. For v1.15.3, a manual PR (#4816) added the version to the catalog templates. This step was missed for v1.15.4.

### Changes

- Updates `BUNDLE_NAME` to v1.15.4 in `hack/index-render-template.sh`
- Adds v1.15.4 entry to `pipelines-1.15` channel in all OCP versions (v4.12, v4.14, v4.15, v4.16, v4.17, v4.18)
- Adds v1.15.4 `olm.bundle` entry in all OCP versions

### Fixes

This unblocks the failing Konflux pipelines for catalog PRs:
- #14327 (v4.12)
- #14328 (v4.14)
- #14326 (v4.15)
- #14329 (v4.16)
- #14324 (v4.17)

### Error that was occurring

```
level=fatal msg="failed to load or rebuild cache: failed to rebuild cache: 
build package index: process package \"openshift-pipelines-operator-rh\": 
package \"openshift-pipelines-operator-rh\", bundle \"openshift-pipelines-operator-rh.v1.15.4\" 
not found in any channel entries"
```

## Test Plan

- [x] Merge this PR
- [x] Close failing catalog PRs (#14327, #14328, #14326, #14329, #14324)
- [ ] Re-run `index-render-template` workflow
- [ ] Verify new catalog PRs pass Konflux pipelines