### PR TITLE
fix(1.15.4): Restore v1.15.3 bundle image to original

### DIFF
--- a/.konflux/olm-catalog/index/v4.18/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.18/catalog-template.json
@@ -245,7 +245,7 @@
     {
       "schema": "olm.bundle",
       "name": "openshift-pipelines-operator-rh.v1.15.3",
-      "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:e9eb98ac08453a63c534fe6f6ba75bc6989e9d171770aab6e971d1c4617c7535"
+      "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:0ba1efe8f9fce499ec4259ea39eef5e0f0536185e84c1e84b766ae3efa2d9b37"
     },
     {
       "schema": "olm.bundle",


### PR DESCRIPTION
## Problem

Catalog PRs are failing with:
```
Error: creating diff: rendering the catalog: catalog name "rhtas-fbc": building File-Based Catalog from template: ...
render error: duplicate bundle "openshift-pipelines-operator-rh.v1.15.4"
```

## Root Cause

When PR #14338 added v1.15.4 to `catalog-template.json`, the v1.15.3 entry had already been updated by the `index-render-template` workflow to point to the new v1.15.4 bundle image. This caused both entries to have the same image SHA:

- v1.15.3: `sha256:e9eb98ac...` (WRONG - this is v1.15.4's image)
- v1.15.4: `sha256:e9eb98ac...` (CORRECT)

When `opm render-template` pulls and renders these images, it extracts the CSV metadata from each, and both resolve to `v1.15.4`, causing the duplicate error.

## Fix

Restore v1.15.3's bundle image to its original SHA for all OCP versions (4.14-4.18):
- v1.15.3: `sha256:0ba1efe8f9fce499ec4259ea39eef5e0f0536185e84c1e84b766ae3efa2d9b37`
- v1.15.4: `sha256:e9eb98ac08453a63c534fe6f6ba75bc6989e9d171770aab6e971d1c4617c7535`

## Testing

After this merges:
1. Close failing catalog PRs (#14339, #14340, #14342, #14343, #14344)
2. Re-run `index-render-template` workflow
3. New catalog PRs should pass without duplicate bundle errors

/lgtm
/approve