### PR TITLE
fix(1.15.4): Update Go builder to v1.25 for Go 1.25.0 support

### DIFF
--- a/.konflux/dockerfiles/operator.Dockerfile
+++ b/.konflux/dockerfiles/operator.Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23
+ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25
 ARG RUNTIME=registry.redhat.io/ubi8/ubi:latest@sha256:bcfca5f27e2d2a822bdbbe7390601edefee48c3cae03b552a33235dcca4a0e24
 
 FROM $GO_BUILDER AS builder

--- a/.konflux/dockerfiles/proxy.Dockerfile
+++ b/.konflux/dockerfiles/proxy.Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23
+ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25
 ARG RUNTIME=registry.redhat.io/ubi8/ubi:latest@sha256:bcfca5f27e2d2a822bdbbe7390601edefee48c3cae03b552a33235dcca4a0e24
 
 FROM $GO_BUILDER as builder

--- a/.konflux/dockerfiles/webhook.Dockerfile
+++ b/.konflux/dockerfiles/webhook.Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23
+ARG GO_BUILDER=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25
 ARG RUNTIME=registry.redhat.io/ubi8/ubi:latest@sha256:bcfca5f27e2d2a822bdbbe7390601edefee48c3cae03b552a33235dcca4a0e24
 
 FROM $GO_BUILDER AS builder


### PR DESCRIPTION
## Summary

Update the Go builder image from `v1.23` to `v1.25` to support Go 1.25.0 requirement from upstream sync (PR #14238).

## Changes

| File | Change |
|------|--------|
| `.konflux/dockerfiles/operator.Dockerfile` | `v1.23` → `v1.25` |
| `.konflux/dockerfiles/proxy.Dockerfile` | `v1.23` → `v1.25` |
| `.konflux/dockerfiles/webhook.Dockerfile` | `v1.23` → `v1.25` |

## Context

PR #14238 synced upstream changes that require Go 1.25.0:
```
go: go.mod requires go >= 1.25.0 (running go 1.23.10; GOTOOLCHAIN=local)
```

The runtime base image remains `ubi8/ubi` (RHEL 8) — only the builder is updated.

## Testing

Konflux PR pipeline will validate the build works with the new builder.