### PR TITLE
chore: Rebuild index images for 4.16, 4.17, 4.18

### DIFF
--- a/.konflux/olm-catalog/index/v4.14/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.14/Dockerfile.catalog
@@ -1,3 +1,4 @@
+# Rebuild trigger: 1.15.4 release 2026-01-29
 FROM registry.redhat.io/openshift4/ose-operator-registry:v4.14
 
 ENTRYPOINT ["/bin/opm"]

--- a/.konflux/olm-catalog/index/v4.16/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.16/Dockerfile.catalog
@@ -1,3 +1,4 @@
+# Rebuild trigger: 1.15.4 release 2026-01-29
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.16
 
 ENTRYPOINT ["/bin/opm"]

--- a/.konflux/olm-catalog/index/v4.17/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.17/Dockerfile.catalog
@@ -1,3 +1,4 @@
+# Rebuild trigger: 1.15.4 release 2026-01-29
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.17
 
 ENTRYPOINT ["/bin/opm"]

--- a/.konflux/olm-catalog/index/v4.18/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.18/Dockerfile.catalog
@@ -1,3 +1,4 @@
+# Rebuild trigger: 1.15.4 release 2026-01-29
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.18
 
 ENTRYPOINT ["/bin/opm"]

--- a/.konflux/olm-catalog/index/v4.19/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.19/Dockerfile.catalog
@@ -1,3 +1,4 @@
+# Rebuild trigger: 1.15.4 release 2026-01-29
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 ENTRYPOINT ["/bin/opm"]

--- a/.konflux/olm-catalog/index/v4.20/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.20/Dockerfile.catalog
@@ -1,3 +1,4 @@
+# Rebuild trigger: 1.15.4 release 2026-01-29
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 ENTRYPOINT ["/bin/opm"]

--- a/.konflux/olm-catalog/index/v4.21/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.21/Dockerfile.catalog
@@ -1,3 +1,4 @@
+# Rebuild trigger: 1.15.4 release 2026-01-29
 FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
## Summary
- Trigger Konflux on-push rebuilds for stale index images (4.16, 4.17, 4.18)
- These haven't been rebuilt since April/May 2025
- Need fresh builds with latest 1.15.4 content before stage release

## Changes
- Added rebuild trigger comment to:
  - `.konflux/olm-catalog/index/v4.16/Dockerfile.catalog`
  - `.konflux/olm-catalog/index/v4.17/Dockerfile.catalog`
  - `.konflux/olm-catalog/index/v4.18/Dockerfile.catalog`

## Context
Index images for 4.19, 4.20, 4.21 were rebuilt Jan 27. 4.14 was rebuilt Jan 28.
Only 4.16, 4.17, 4.18 remain stale.