### PR TITLE
fix: remove hardcoded namespace from operator ServiceMonitor

### DIFF
--- a/.konflux/olm-catalog/bundle/manifests/openshift-pipelines-operator-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/.konflux/olm-catalog/bundle/manifests/openshift-pipelines-operator-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -11,9 +11,6 @@ spec:
   - interval: 10s
     port: http-metrics
   jobLabel: name
-  namespaceSelector:
-    matchNames:
-    - openshift-operators
   selector:
     matchLabels:
       name: openshift-pipelines-operator


### PR DESCRIPTION
fix [SRVKP-10509](https://issues.redhat.com//browse/SRVKP-10509)
Follows https://github.com/tektoncd/operator/pull/3205