### PR TITLE
chore: bump version labels to 1.15.4

### DIFF
--- a/.konflux/dockerfiles/operator.Dockerfile
+++ b/.konflux/dockerfiles/operator.Dockerfile
@@ -26,7 +26,7 @@ COPY head ${KO_DATA_PATH}/HEAD
 LABEL \
       com.redhat.component="openshift-pipelines-rhel8-operator-container" \
       name="openshift-pipelines/pipelines-rhel8-operator" \
-      version="1.15.3" \
+      version="1.15.4" \
       cpe="cpe:/a:redhat:openshift_pipelines:1.15::el8" \
       summary="Red Hat OpenShift Pipelines Operator" \
       maintainer="pipelines-extcomm@redhat.com" \

--- a/.konflux/dockerfiles/proxy.Dockerfile
+++ b/.konflux/dockerfiles/proxy.Dockerfile
@@ -24,7 +24,7 @@ COPY head ${KO_DATA_PATH}/HEAD
 LABEL \
       com.redhat.component="openshift-pipelines-operator-proxy-rhel8-container" \
       name="openshift-pipelines/pipelines-operator-proxy-rhel8" \
-      version="1.15.3" \
+      version="1.15.4" \
       summary="Red Hat OpenShift Pipelines Operator Proxy" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Operator Proxy" \

--- a/.konflux/dockerfiles/webhook.Dockerfile
+++ b/.konflux/dockerfiles/webhook.Dockerfile
@@ -26,7 +26,7 @@ COPY head ${KO_DATA_PATH}/HEAD
 LABEL \
       com.redhat.component="openshift-pipelines-operator-webhook-rhel8-container" \
       name="openshift-pipelines/pipelines-operator-webhook-rhel8" \
-      version="1.15.3" \
+      version="1.15.4" \
       cpe="cpe:/a:redhat:openshift_pipelines:1.15::el8" \
       summary="Red Hat OpenShift Pipelines Operator Webhook" \
       maintainer="pipelines-extcomm@redhat.com" \


### PR DESCRIPTION
Bump version label from 1.15.3 to 1.15.4 in operator, proxy, and webhook Dockerfiles.