### PR TITLE
Update serve-tkn-cli to Konflux-built image for 1.15.x

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -57,8 +57,8 @@ images:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/1-15/cli-tkn-rhel8@sha256:51ecd29b1199057ece51eaa5911c2243561573d361bfccb44106a1c88444aacd
   - name: IMAGE_ADDONS_TKN
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/1-15/cli-tkn-rhel8@sha256:51ecd29b1199057ece51eaa5911c2243561573d361bfccb44106a1c88444aacd
-  - name: IMAGE_ADDONS_TKN_CLI_SERVE # FIXME: we need to figure how to manage this in konflux. For now, using released version (1.16)
-    value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel8@sha256:322ef2385620661a7914f47c73a6d145ec0c9ce1ccde30645bb66148545ddc96
+  - name: IMAGE_ADDONS_TKN_CLI_SERVE
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/1-15/serve-tkn-cli-rhel8@sha256:3904b7a15ffabc11ff9d8abe1ee9fae7aa4f32080b1cefe39292908686a5d674
   # manual-approval-gate
   - name: IMAGE_MAG_MANUAL_APPROVAL
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/1-15/manual-approval-gate-webhook-rhel8@sha256:29430aa7bc21f00e29b08f8db2f46694db21b1d7f38175800709556caa7c32b4


### PR DESCRIPTION
## Summary

- Replace stale `registry.redhat.io` serve-tkn-cli image (from 1.16 CPaaS build) with fresh Konflux-built image from the `1-15` application
- Removes the `FIXME` comment — serve-tkn-cli is now managed in Konflux via component `serve-tkn-cli-1-15-serve-tkn-cli`
- Completes the serve-tkn-cli CPaaS → Konflux migration for 1.15.4

**Old image:** `registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel8@sha256:322ef238...`
**New image:** `quay.io/redhat-user-workloads/tekton-ecosystem-tenant/1-15/serve-tkn-cli-rhel8@sha256:3904b7a1...`

**Source build:** `serve-tkn-cli-1-15-serve-tkn-cli-on-push-zs2hf` (18/18 tasks passed, EC passed)

/lgtm
/approve