### PR TITLE
chore: retrigger index builds for v4.16, v4.19, v4.20, v4.21

### DIFF
--- a/.konflux/olm-catalog/index/v4.16/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.16/Dockerfile.catalog
@@ -17,3 +17,4 @@ LABEL operators.operatorframework.io.bundle.channels.v1="pipelines-1.15"
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.index.configs.v1=/configs
+# Trigger index rebuild 2026-02-15

--- a/.konflux/olm-catalog/index/v4.19/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.19/Dockerfile.catalog
@@ -18,4 +18,4 @@ LABEL operators.operatorframework.io.bundle.channels.v1="pipelines-1.15"
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.index.configs.v1=/configs
-# Trigger index rebuild Tue Jan 20 12:43:24 IST 2026
+# Trigger index rebuild 2026-02-15

--- a/.konflux/olm-catalog/index/v4.20/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.20/Dockerfile.catalog
@@ -18,4 +18,4 @@ LABEL operators.operatorframework.io.bundle.channels.v1="pipelines-1.15"
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.index.configs.v1=/configs
-# Trigger index rebuild Tue Jan 20 12:43:24 IST 2026
+# Trigger index rebuild 2026-02-15

--- a/.konflux/olm-catalog/index/v4.21/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.21/Dockerfile.catalog
@@ -18,4 +18,4 @@ LABEL operators.operatorframework.io.bundle.channels.v1="pipelines-1.15"
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.index.configs.v1=/configs
-# Trigger index rebuild Tue Jan 20 12:43:24 IST 2026
+# Trigger index rebuild 2026-02-15


### PR DESCRIPTION
Retrigger index image builds via Dockerfile comment change.

- v4.19, v4.20, v4.21: Need new snapshots after IntegrationTestScenario creation
- v4.16: Needs rebuild after persistent fbc-fips-check-oci-ta failure

Signed-off-by: Vibhav Bobade <vibhav.bobde@gmail.com>