### PR TITLE
chore: retrigger index builds for v4.19, v4.20, v4.21

### DIFF
--- a/.konflux/olm-catalog/index/v4.19/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.19/Dockerfile.catalog
@@ -18,4 +18,4 @@ LABEL operators.operatorframework.io.bundle.channels.v1="pipelines-1.15"
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.index.configs.v1=/configs
-# Trigger index rebuild Tue Jan 20 12:43:24 IST 2026
+# Trigger index rebuild 2026-02-15

--- a/.konflux/olm-catalog/index/v4.20/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.20/Dockerfile.catalog
@@ -18,4 +18,4 @@ LABEL operators.operatorframework.io.bundle.channels.v1="pipelines-1.15"
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.index.configs.v1=/configs
-# Trigger index rebuild Tue Jan 20 12:43:24 IST 2026
+# Trigger index rebuild 2026-02-15

--- a/.konflux/olm-catalog/index/v4.21/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.21/Dockerfile.catalog
@@ -18,4 +18,4 @@ LABEL operators.operatorframework.io.bundle.channels.v1="pipelines-1.15"
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.index.configs.v1=/configs
-# Trigger index rebuild Tue Jan 20 12:43:24 IST 2026
+# Trigger index rebuild 2026-02-15


### PR DESCRIPTION
Retrigger index builds to get new snapshots after IntegrationTestScenario creation.

Split from #16201 to unblock v4.19/v4.20/v4.21 while v4.16 fbc-fips-check issue is investigated separately.