### PR TITLE
debug: retrigger v4.16 index build for fbc-fips-check investigation

### DIFF
--- a/.konflux/olm-catalog/index/v4.16/Dockerfile.catalog
+++ b/.konflux/olm-catalog/index/v4.16/Dockerfile.catalog
@@ -17,3 +17,4 @@ LABEL operators.operatorframework.io.bundle.channels.v1="pipelines-1.15"
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.index.configs.v1=/configs
+# retrigger build 2026-02-15T19:04:13Z


### PR DESCRIPTION
Temporary PR to investigate fbc-fips-check-oci-ta failure on v4.16 index. Will close after debugging.