### PR TITLE
Wire skip-checks param to fbc-fips-check-oci-ta task

### DIFF
--- a/.tekton/fbc-build.yaml
+++ b/.tekton/fbc-build.yaml
@@ -331,7 +331,7 @@ spec:
         value: task
       resolver: bundles
     when:
-    - input: "false"
+    - input: $(params.skip-checks)
       operator: in
       values:
       - "false"


### PR DESCRIPTION
## Summary
- The `fbc-fips-check-oci-ta` task had a hardcoded `when` clause (`input: "false"`) instead of using `$(params.skip-checks)` like the other 3 check tasks
- This meant the fips check could never be skipped via the `skip-checks` parameter
- Aligns `fbc-fips-check-oci-ta` with `deprecated-base-image-check`, `fbc-target-index-pruning-check`, and `validate-fbc`

## Motivation
The v4.16 index build hits an OOM during the fbc-fips-check task due to the larger catalog size. With this fix, the v4.16 PipelineRun can pass `skip-checks: "true"` to bypass the fips check while all other index builds continue to run it by default.