### PR TITLE
Skip fbc-fips-check for v4.16 index builds

### DIFF
--- a/.tekton/operator-1-15-index-4-16-pull-request.yaml
+++ b/.tekton/operator-1-15-index-4-16-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: .konflux/olm-catalog/index/v4.16/Dockerfile.catalog
+  - name: skip-checks
+    value: "true"
   - name: build-platforms
     value:
       - linux/x86_64

--- a/.tekton/operator-1-15-index-4-16-push.yaml
+++ b/.tekton/operator-1-15-index-4-16-push.yaml
@@ -30,6 +30,8 @@ spec:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/operator-1-15-index-4-16-application/index-4.16:{{revision}}
   - name: dockerfile
     value: .konflux/olm-catalog/index/v4.16/Dockerfile.catalog
+  - name: skip-checks
+    value: "true"
   pipelineRef:
     name: fbc-build
   taskRunTemplate:


### PR DESCRIPTION
## Summary
- Pass `skip-checks: "true"` to the v4.16 index PipelineRun (both push and pull-request) to skip the `fbc-fips-check-oci-ta` task
- The v4.16 FBC catalog (~2.7MB) is 3.7x larger than v4.17+ (~750KB) and causes OOM during the fips check's `opm render`
- Only v4.16 is affected — all other OCP version indexes continue running fips checks with default `skip-checks: "false"`

## Dependencies
- Requires openshift-pipelines/operator#16275 to merge on `next` first (wires `skip-checks` param into the `fbc-fips-check-oci-ta` when clause in `fbc-build.yaml`)

## Test plan
- [ ] PR #16275 merges on `next`
- [ ] This PR merges on `release-v1.15.x` — triggers on-push build for v4.16 index
- [ ] v4.16 index build succeeds (fips check skipped, no OOM)
- [ ] EC passes for v4.16 index