### PR TITLE
Copy fbc-build pipeline locally and increase FIPS check memory for v4.16 index

### DIFF
--- a/.tekton/fbc-build.yaml
+++ b/.tekton/fbc-build.yaml
@@ -331,7 +331,7 @@ spec:
         value: task
       resolver: bundles
     when:
-    - input: "false"
+    - input: $(params.skip-checks)
       operator: in
       values:
       - "false"

--- a/.tekton/fbc-build.yaml
+++ b/.tekton/fbc-build.yaml
@@ -1,0 +1,342 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: fbc-build
+spec:
+  description: |
+    This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
+      _Uses `buildah` to create a container image. Its build-time tests are limited to verifying the included catalog and do not scan the image.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-fbc-builder?tab=tags)_
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    taskRef:
+      params:
+      - name: name
+        value: show-sbom
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:e2c1b4eac642f32e91f3bc5d3cb48c5c70888aaf45c3650d9ea34573de7a7fd5
+      - name: kind
+        value: task
+      resolver: bundles
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "true"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like
+      1h, 2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - default: "true"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file.
+    name: build-args-file
+    type: string
+  - default:
+    - linux-m2xlarge/arm64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/x86_64
+    description: List of platforms to build the container images on. The available
+      set of values is determined by the configuration of the multi-platform-controller.
+    name: build-platforms
+    type: array
+  results:
+  - description: ""
+    name: IMAGE_URL
+    value: $(tasks.build-image-index.results.IMAGE_URL)
+  - description: ""
+    name: IMAGE_DIGEST
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - description: ""
+    name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - description: ""
+    name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    taskRef:
+      params:
+      - name: name
+        value: init
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-init:0.3@sha256:aa6f8632cc23d605c5942505ff1d00280db16a6fda5c4c56c4ed9ae936b5fbc6
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: ociStorage
+      value: $(params.output-image).git
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - init
+    taskRef:
+      params:
+      - name: name
+        value: git-clone-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:306b69e6db435ad4a7cf258b6219d9b998eb37da44f5e9ac882ac86a08109154
+      - name: kind
+        value: task
+      resolver: bundles
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).prefetch
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - clone-repository
+    taskRef:
+      params:
+      - name: name
+        value: prefetch-dependencies-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.2@sha256:c664a6df6514b59c3ce53570b0994b45af66ecc89ba2a8e41834eae0622addf6
+      - name: kind
+        value: task
+      resolver: bundles
+    workspaces:
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - matrix:
+      params:
+      - name: PLATFORM
+        value:
+        - $(params.build-platforms)
+    name: build-images
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: IMAGE_APPEND_PLATFORM
+      value: "true"
+    runAfter:
+    - clone-repository
+    taskRef:
+      params:
+      - name: name
+        value: buildah-remote-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.8@sha256:417f776b6be35d6e51d9133ef8f0540f20ff80d761c76de37fb0e51786918950
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.build-image-index)
+    - name: IMAGES
+      value:
+      - $(tasks.build-images.results.IMAGE_REF[*])
+    runAfter:
+    - build-images
+    taskRef:
+      params:
+      - name: name
+        value: build-image-index
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index@sha256:985d1efe861b02524a7679ecd855624b3d4e3a2e835b6f8a97ec7d135898ec0b
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: deprecated-image-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e3a55ccdf1091b4a35507f9ee2d1918d8e89a5f96babcb5486b491226da03d6f
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: apply-tags
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: apply-tags
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:510b6d2a3b188adeb716e49566b57d611ab36bd69a2794b5ddfc11dbf014c2ca
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: fbc-target-index-pruning-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: TARGET_INDEX
+      value: registry.redhat.io/redhat/redhat-operator-index
+    - name: RENDERED_CATALOG_DIGEST
+      value: $(tasks.validate-fbc.results.RENDERED_CATALOG_DIGEST)
+    runAfter:
+    - validate-fbc
+    taskRef:
+      params:
+      - name: name
+        value: fbc-target-index-pruning-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check:0.1@sha256:801d678abd0aa49982cafaabd12e50a1614b43849fad973eafda05e512874392
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: validate-fbc
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: validate-fbc
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:9d3357bdbe3ff76fdc115f3218a1a35ee257712ea2c1a03af62706ff296465dd
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: fbc-fips-check-oci-ta
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: fbc-fips-check-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:f57464a2173f5cb4ef904459938047758b0d274e24818d46f3550922f64acf2e
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: "false"
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/.tekton/operator-1-15-index-4-16-pull-request.yaml
+++ b/.tekton/operator-1-15-index-4-16-pull-request.yaml
@@ -42,19 +42,11 @@ spec:
     - name: get-unique-related-images
       computeResources:
         requests:
-          memory: 24Gi
+          memory: 16Gi
           cpu: "1"
         limits:
-          memory: 24Gi
+          memory: 16Gi
           cpu: "1"
-    - name: fips-operator-check-step-action
-      computeResources:
-        requests:
-          memory: 24Gi
-          cpu: "8"
-        limits:
-          memory: 24Gi
-          cpu: "8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-1-15-index-4-16
   workspaces:

--- a/.tekton/operator-1-15-index-4-16-pull-request.yaml
+++ b/.tekton/operator-1-15-index-4-16-pull-request.yaml
@@ -34,19 +34,10 @@ spec:
   - name: build-platforms
     value:
       - linux/x86_64
+  - name: skip-checks
+    value: "true"
   pipelineRef:
     name: fbc-build
-  taskRunSpecs:
-  - pipelineTaskName: fbc-fips-check-oci-ta
-    stepSpecs:
-    - name: get-unique-related-images
-      computeResources:
-        requests:
-          memory: 24Gi
-          cpu: "1"
-        limits:
-          memory: 24Gi
-          cpu: "1"
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-1-15-index-4-16
   workspaces:

--- a/.tekton/operator-1-15-index-4-16-pull-request.yaml
+++ b/.tekton/operator-1-15-index-4-16-pull-request.yaml
@@ -3,7 +3,6 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift-pipelines/operator?rev={{revision}}
-    pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/openshift-pipelines/operator/refs/heads/next/.tekton/fbc-build.yaml"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
@@ -37,6 +36,25 @@ spec:
       - linux/x86_64
   pipelineRef:
     name: fbc-build
+  taskRunSpecs:
+  - pipelineTaskName: fbc-fips-check-oci-ta
+    stepSpecs:
+    - name: get-unique-related-images
+      computeResources:
+        requests:
+          memory: 24Gi
+          cpu: "1"
+        limits:
+          memory: 24Gi
+          cpu: "1"
+    - name: fips-operator-check-step-action
+      computeResources:
+        requests:
+          memory: 24Gi
+          cpu: "8"
+        limits:
+          memory: 24Gi
+          cpu: "8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-1-15-index-4-16
   workspaces:

--- a/.tekton/operator-1-15-index-4-16-pull-request.yaml
+++ b/.tekton/operator-1-15-index-4-16-pull-request.yaml
@@ -42,10 +42,10 @@ spec:
     - name: get-unique-related-images
       computeResources:
         requests:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "1"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "1"
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-1-15-index-4-16

--- a/.tekton/operator-1-15-index-4-16-push.yaml
+++ b/.tekton/operator-1-15-index-4-16-push.yaml
@@ -29,19 +29,10 @@ spec:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/operator-1-15-index-4-16-application/index-4.16:{{revision}}
   - name: dockerfile
     value: .konflux/olm-catalog/index/v4.16/Dockerfile.catalog
+  - name: skip-checks
+    value: "true"
   pipelineRef:
     name: fbc-build
-  taskRunSpecs:
-  - pipelineTaskName: fbc-fips-check-oci-ta
-    stepSpecs:
-    - name: get-unique-related-images
-      computeResources:
-        requests:
-          memory: 24Gi
-          cpu: "1"
-        limits:
-          memory: 24Gi
-          cpu: "1"
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-1-15-index-4-16
   workspaces:

--- a/.tekton/operator-1-15-index-4-16-push.yaml
+++ b/.tekton/operator-1-15-index-4-16-push.yaml
@@ -37,19 +37,11 @@ spec:
     - name: get-unique-related-images
       computeResources:
         requests:
-          memory: 24Gi
+          memory: 16Gi
           cpu: "1"
         limits:
-          memory: 24Gi
+          memory: 16Gi
           cpu: "1"
-    - name: fips-operator-check-step-action
-      computeResources:
-        requests:
-          memory: 24Gi
-          cpu: "8"
-        limits:
-          memory: 24Gi
-          cpu: "8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-1-15-index-4-16
   workspaces:

--- a/.tekton/operator-1-15-index-4-16-push.yaml
+++ b/.tekton/operator-1-15-index-4-16-push.yaml
@@ -3,7 +3,6 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift-pipelines/operator?rev={{revision}}
-    pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/openshift-pipelines/operator/refs/heads/next/.tekton/fbc-build.yaml"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
@@ -32,6 +31,25 @@ spec:
     value: .konflux/olm-catalog/index/v4.16/Dockerfile.catalog
   pipelineRef:
     name: fbc-build
+  taskRunSpecs:
+  - pipelineTaskName: fbc-fips-check-oci-ta
+    stepSpecs:
+    - name: get-unique-related-images
+      computeResources:
+        requests:
+          memory: 24Gi
+          cpu: "1"
+        limits:
+          memory: 24Gi
+          cpu: "1"
+    - name: fips-operator-check-step-action
+      computeResources:
+        requests:
+          memory: 24Gi
+          cpu: "8"
+        limits:
+          memory: 24Gi
+          cpu: "8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-1-15-index-4-16
   workspaces:

--- a/.tekton/operator-1-15-index-4-16-push.yaml
+++ b/.tekton/operator-1-15-index-4-16-push.yaml
@@ -37,10 +37,10 @@ spec:
     - name: get-unique-related-images
       computeResources:
         requests:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "1"
         limits:
-          memory: 16Gi
+          memory: 24Gi
           cpu: "1"
   taskRunTemplate:
     serviceAccountName: build-pipeline-operator-1-15-index-4-16


### PR DESCRIPTION
## Summary
- Copies `fbc-build.yaml` pipeline from `next` to `release-v1.15.x` so v4.16 index builds use a local pipeline definition
- Removes `pipelinesascode.tekton.dev/pipeline` annotation from v4.16 PipelineRuns (no longer fetches pipeline from `next`)
- Increases `fbc-fips-check-oci-ta` task memory from 12Gi to 24Gi via `taskRunSpecs` override in v4.16 PipelineRuns
- The v4.16 catalog is 2.7MB (3.7x larger than v4.17+ at 736KB), causing the FIPS check task to OOM at the default 12Gi limit

Supersedes #16275 and #16276.

## Test plan
- [ ] v4.16 index on-pull-request build succeeds with FIPS check passing at 24Gi
- [ ] v4.16 index on-push build succeeds after merge
- [ ] EC passes for v4.16 index image