### PR TITLE
Update v4.16 catalog with latest bundle SHA

### DIFF
--- a/.konflux/olm-catalog/index/v4.16/catalog-template.json
+++ b/.konflux/olm-catalog/index/v4.16/catalog-template.json
@@ -435,7 +435,7 @@
     {
       "schema": "olm.bundle",
       "name": "openshift-pipelines-operator-rh.v1.15.4",
-      "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:231e484f97cdc3e53b6671442b773a361bdad24a6266bfd007ad96ed6139109b"
+      "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:9f575942d31a2845ec6948d3d0c4a2b80a248208c272a5eb594170bc3044d6d3"
     }
   ]
 }

--- a/.konflux/olm-catalog/index/v4.16/catalog/openshift-pipelines-operator-rh/catalog.json
+++ b/.konflux/olm-catalog/index/v4.16/catalog/openshift-pipelines-operator-rh/catalog.json
@@ -6858,7 +6858,7 @@
     "schema": "olm.bundle",
     "name": "openshift-pipelines-operator-rh.v1.15.4",
     "package": "openshift-pipelines-operator-rh",
-    "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:231e484f97cdc3e53b6671442b773a361bdad24a6266bfd007ad96ed6139109b",
+    "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:9f575942d31a2845ec6948d3d0c4a2b80a248208c272a5eb594170bc3044d6d3",
     "properties": [
         {
             "type": "olm.gvk",
@@ -7189,11 +7189,11 @@
         },
         {
             "name": "IMAGE_MAG_TEKTON_TASKGROUP_CONTROLLER",
-            "image": "quay.io/openshift-pipeline/pipelines-manual-approval-gate-controller-rhel8@sha256:4fe3ff4e2018b533964ec83e73ec747827e2f14c2cf8de9b3aa99d9ae49e3146"
+            "image": "quay.io/openshift-pipeline/pipelines-manual-approval-gate-controller-rhel8@sha256:dabe7e1de212226e744dae0664f5229f38bd87c431b93ac2848bee58b713f177"
         },
         {
             "name": "IMAGE_MAG_MANUAL_APPROVAL",
-            "image": "quay.io/openshift-pipeline/pipelines-manual-approval-gate-webhook-rhel8@sha256:6c33f9fed54cbfc354e186dffdd08c88bb209b098f7f6231dd293b1518dd9979"
+            "image": "quay.io/openshift-pipeline/pipelines-manual-approval-gate-webhook-rhel8@sha256:e313b78fd58ea659897c5a964cf7becaf254b1f1097f8feb84e7375e94509295"
         },
         {
             "name": "IMAGE_PIPELINES_ARG__NOP_IMAGE",
@@ -7201,7 +7201,7 @@
         },
         {
             "name": "",
-            "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:231e484f97cdc3e53b6671442b773a361bdad24a6266bfd007ad96ed6139109b"
+            "image": "quay.io/openshift-pipeline/pipelines-operator-bundle@sha256:9f575942d31a2845ec6948d3d0c4a2b80a248208c272a5eb594170bc3044d6d3"
         },
         {
             "name": "IMAGE_PIPELINES_PROXY",
@@ -7213,15 +7213,15 @@
         },
         {
             "name": "IMAGE_PAC_PAC_CONTROLLER",
-            "image": "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel8@sha256:57861ca35b143710d38ffd839e6dc7c0af4b5b29430eafcf3be1cfef854c2a94"
+            "image": "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel8@sha256:9161e223704e4f9958c2d1be1ca3a8d3ccaef1872679d320e0ad285748ec7571"
         },
         {
             "name": "IMAGE_PAC_PAC_WATCHER",
-            "image": "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel8@sha256:bd50b007d0923a798478a9653928effad68c367a18667875f9f44a370eeb9e8e"
+            "image": "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel8@sha256:2ea27b4c8ee99095037770658e8c6fe65b913776754def9c60b22f951437b140"
         },
         {
             "name": "IMAGE_PAC_PAC_WEBHOOK",
-            "image": "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel8@sha256:215f7c39b2ac68b5d5ba277de98021ba687ca9a79e25a2ab0f380b77d7d44d5d"
+            "image": "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel8@sha256:ef12d00a994833cf3afa67475f5690510717c0d6b9fc9e8be4284a13be1018a8"
         },
         {
             "name": "IMAGE_PIPELINES_CONTROLLER",
@@ -7245,7 +7245,7 @@
         },
         {
             "name": "IMAGE_ADDONS_TKN_CLI_SERVE",
-            "image": "quay.io/openshift-pipeline/pipelines-serve-tkn-cli-rhel8@sha256:ecee66ca69051e295232a8f1bb94238d583dd975caba43185e53bffb2d553eb0"
+            "image": "quay.io/openshift-pipeline/pipelines-serve-tkn-cli-rhel8@sha256:80f535f2c4e4f8fde172aabd900803761a8037b37b52b798a29e4878a00d8696"
         },
         {
             "name": "IMAGE_TRIGGERS_TEKTON_TRIGGERS_CONTROLLER",


### PR DESCRIPTION
## Summary

The v4.16 catalog was not regenerated after the bundle update to `9f57594` because the v4.16 on-push build was failing due to the upstream FIPS xrealloc integer overflow bug (now fixed by PR #16277 with `skip-checks=true`).

This updates the v1.15.4 bundle image reference and all associated component images to match the latest SHAs already used by all other OCP versions (4.14, 4.17-4.21):

- **Bundle**: `231e484` → `9f57594`
- **PAC controller**: `57861ca` → `9161e22` (VERSION 1.15.3 → 1.15.4)
- **PAC watcher**: `bd50b00` → `2ea27b4` (VERSION 1.15.3 → 1.15.4)
- **PAC webhook**: `215f7c3` → `ef12d00` (VERSION 1.15.3 → 1.15.4)
- **MAG controller**: `4fe3ff4` → `dabe7e1`
- **MAG webhook**: `6c33f9f` → `e313b78`
- **serve-tkn-cli**: `ecee66c` → `80f535f` (VERSION → 1.15.4)

This should resolve the v4.16 EC failures (25 failures → 0) since the updated bundle has proper Konflux attestations.