### PR TITLE
fix: update PaC kodata path after upstream move to tektoncd/pipelines-as-code

### DIFF
--- a/hack/operator-fetch-payload.sh
+++ b/hack/operator-fetch-payload.sh
@@ -95,7 +95,7 @@ env SERVE_REF="$SERVE_REF" yq e -i '
 
 # Mutate pipelines-as-code payload
 for d in controller watcher webhook; do
-    yq e -i "(select (.kind == \"Deployment\") | select (.metadata.name == \"pipelines-as-code-${d}\") | .spec.template.spec.containers[0].command) = [\"/ko-app/pipelines-as-code-${d}\"]" .konflux/olm-catalog/bundle/kodata/tekton-addon/pipelines-as-code/*/release.yaml
+    yq e -i "(select (.kind == \"Deployment\") | select (.metadata.name == \"pipelines-as-code-${d}\") | .spec.template.spec.containers[0].command) = [\"/ko-app/pipelines-as-code-${d}\"]" .konflux/olm-catalog/bundle/kodata/pipelines-as-code/*/release.yaml
 done
 
 # Mutate manual-approval-gate payload


### PR DESCRIPTION
The upstream tektoncd/operator commit 71ed26f494 (Apr 8) moved PaC release artifacts from kodata/tekton-addon/pipelines-as-code/ to kodata/pipelines-as-code/. This broke the update-sources workflow on the next branch since Apr 22.