### PR TITLE
Add repo name to Slack build failure notifications

### DIFF
--- a/.tekton/docker-build-ta.yaml
+++ b/.tekton/docker-build-ta.yaml
@@ -95,6 +95,10 @@ spec:
     type: string
     default: "konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com"
     description: Konflux UI hostname for logs URL
+  - name: repo-name
+    type: string
+    default: "operator"
+    description: Short repository name for Slack notifications
   results:
   - description: ""
     name: IMAGE_URL
@@ -565,8 +569,8 @@ spec:
     params:
     - name: message
       value: |
-        :red_circle: *Build Failure*
-        *Repo:* $(params.git-url)
+        :red_circle: *Build Failure on $(params.repo-name)*
+        *Commit:* $(params.git-url)/commit/$(params.revision)
         *PipelineRun:* $(context.pipelineRun.name)
         *Logs:* https://$(params.konflux-ui-host)/ns/tekton-ecosystem-tenant/pipelinerun/$(context.pipelineRun.name)
         Please investigate and fix this failure.

--- a/.tekton/fbc-build.yaml
+++ b/.tekton/fbc-build.yaml
@@ -29,8 +29,8 @@ spec:
     params:
     - name: message
       value: |
-        :red_circle: *Build Failure*
-        *Repo:* $(params.git-url)
+        :red_circle: *Build Failure on $(params.repo-name)*
+        *Commit:* $(params.git-url)/commit/$(params.revision)
         *PipelineRun:* $(context.pipelineRun.name)
         *Logs:* https://$(params.konflux-ui-host)/ns/tekton-ecosystem-tenant/pipelinerun/$(context.pipelineRun.name)
         Please investigate and fix this failure.
@@ -126,6 +126,10 @@ spec:
     type: string
     default: "konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com"
     description: Konflux UI hostname for logs URL
+  - name: repo-name
+    type: string
+    default: "operator"
+    description: Short repository name for Slack notifications
   results:
   - description: ""
     name: IMAGE_URL


### PR DESCRIPTION
## Summary
- Add `repo-name` pipeline parameter (default: `"operator"`) to both `docker-build-ta` and `fbc-build` pipelines
- Update Slack notification title from `Build Failure` to `Build Failure on <repo-name>` for better identification
- Remove redundant `*Repo:*` field from the message since the repo name is now in the title