### PR TITLE
ci(SRVKP-12442): add registry mirror for OLM catalog rendering

### DIFF
--- a/.github/workflows/render-olm-catalog.yaml
+++ b/.github/workflows/render-olm-catalog.yaml
@@ -47,6 +47,28 @@ jobs:
           DOCKER_JSON: ${{ secrets.DOCKER_REGISTRY_SECRET }}
         run: |
           echo ${DOCKER_JSON} > $DOCKER_CONFIG/config.json
+      - name: Configure registry mirrors
+        run: |
+          set -x
+          CONFIG_DIR=$HOME/.config/containers/registries.conf.d
+          sudo mkdir -p $CONFIG_DIR
+
+          cat <<EOF | sudo tee $CONFIG_DIR/mirror.conf
+          [[registry]]
+          location = "registry.redhat.io/openshift-pipelines"
+
+          [[registry.mirror]]
+          location = "quay.io/redhat-user-workloads/tekton-ecosystem-tenant"
+
+          [[registry]]
+          location = "registry.stage.redhat.io/openshift-pipelines"
+
+          [[registry.mirror]]
+          location = "quay.io/redhat-user-workloads/tekton-ecosystem-tenant"
+          EOF
+
+          cat $CONFIG_DIR/mirror.conf
+
       - name: Generate OLM Bundles
         run: |
           curl -sSfLo /usr/local/bin/opm "https://github.com/operator-framework/operator-registry/releases/download/v1.47.0/linux-amd64-opm"
@@ -59,7 +81,14 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           command: |
-            ./hack/render-catalog.sh
+            docker run --platform linux/amd64 --rm \
+              -e REGISTRY_AUTH_FILE=/root/.docker/config.json \
+              -v "$HOME/.config/containers:/root/.config/containers" \
+              -v "$HOME/.docker/config.json:/root/.docker/config.json:ro" \
+              -v "$(pwd):/work" \
+              -w /work \
+              quay.io/openshift-pipeline/ci \
+              ./hack/render-catalog.sh
       - name: Commit Changes and Generate PR
         if: github.event_name != 'pull_request'
         run: |

--- a/olm/release-stage.txt
+++ b/olm/release-stage.txt
@@ -1,1 +1,1 @@
-devel
+production


### PR DESCRIPTION
Configure registries.conf in the render-olm-catalog GHA to mirror registry.redhat.io and registry.stage.redhat.io to the tenant Quay repository. This allows opm to resolve bundle images that have not yet been promoted to production or staging registries.


Assisted-by: Claude Opus 4.6 (via Claude Code)