### PR TITLE
ci(SRVKP-11627): configure IDMS in release test pipeline

### DIFF
--- a/.konflux/tekton/release-test-pipeline.yaml
+++ b/.konflux/tekton/release-test-pipeline.yaml
@@ -151,6 +151,11 @@ spec:
                 value: $(params.INSTANCE_TYPE)
               - name: fips
                 value: true
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/openshift-pipelines/
+                    mirrors:
+                      - quay.io/redhat-user-workloads/tekton-ecosystem-tenant
     # Create Catalog Source to install Operator
     - name: create-catalog-source
       runAfter:


### PR DESCRIPTION
Add imageContentSources param to the create-cluster step so ephemeral Hypershift clusters are provisioned with IDMS mirroring registry.redhat.io/openshift-pipelines/ to the Konflux mirror at quay.io/redhat-user-workloads/tekton-ecosystem-tenant.


Assisted-by: Claude Opus 4.6 (via Cursor)