### PR TITLE
[DNM] fix: release-tests

### DIFF
--- a/.konflux/tekton/release-test-pipeline.yaml
+++ b/.konflux/tekton/release-test-pipeline.yaml
@@ -99,14 +99,14 @@ spec:
             script: |
               #!/usr/bin/env bash
               set -e
-              
+
               # Extract OCP version from COMPONENT_NAME
               # Expected format: operator-1-22-index-4-20 -> 4.20
               echo "Component Name: $COMPONENT_NAME"
-              
+
               # Extract version pattern (e.g., "4-19" from "operator-1-22-index-4-20")
               VERSION_PATTERN=$(echo "$COMPONENT_NAME" | grep -oE '[0-9]+-[0-9]+' | tail -1)
-              
+
               if [ -z "$VERSION_PATTERN" ]; then
                 echo "Warning: Could not extract version from application name, will use default"
                 OCP_VERSION="4.20"
@@ -115,20 +115,20 @@ spec:
                 OCP_VERSION=$(echo "$VERSION_PATTERN" | tr '-' '.')
                 echo "Extracted OCP Version: $OCP_VERSION"
               fi
-              
+
               echo -n "$OCP_VERSION" | tee /tekton/results/ocpVersion
-              
+
               # Fetch the latest patch version for this OCP version
               echo "Fetching latest patch version for ${OCP_VERSION}..."
               RELEASE_URL="https://multi.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable-multi/latest?prefix=${OCP_VERSION}."
               echo "GET $RELEASE_URL"
-              
+
               RELEASE_INFO=$(curl -s "$RELEASE_URL")
               echo "$RELEASE_INFO"
-              
+
               VERSION=$(echo "$RELEASE_INFO" | jq -r '.name')
               echo "Selected version: $VERSION"
-              
+
               # Write result for create-cluster step
               mkdir -p /tekton/steps/step-extract-and-pick-version/results
               echo -n "$VERSION" | tee /tekton/steps/step-extract-and-pick-version/results/version
@@ -150,12 +150,28 @@ spec:
               - name: instanceType
                 value: $(params.INSTANCE_TYPE)
               - name: fips
-                value: true
-              - name: imageContentSources
-                value: |
-                  - source: registry.redhat.io/openshift-pipelines/
-                    mirrors:
-                      - quay.io/redhat-user-workloads/tekton-ecosystem-tenant
+                value: false
+    # Configure Loki and OpenShift Logging
+    - name: configure-loki-logging
+      runAfter:
+        - provision-cluster
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.RELEASE_TEST_TASKS_REPO)
+          - name: revision
+            value: $(params.RELEASE_TEST_TASKS_BRANCH)
+          - name: pathInRepo
+            value: .konflux/tekton/task-configure-loki-logging.yaml
+      params:
+        - name: EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+        - name: CLUSTER_NAME
+          value: $(tasks.provision-cluster.results.clusterName)
+        - name: IMAGE
+          value: $(params.IMAGE)
+
     # Create Catalog Source to install Operator
     - name: create-catalog-source
       runAfter:
@@ -258,6 +274,28 @@ spec:
           value: "$(tasks.create-catalog-source.results.channel)"
       runAfter:
         - create-catalog-source
+
+    # Setup test user accounts
+    - name: setup-testing-accounts
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.RELEASE_TEST_TASKS_REPO)
+          - name: revision
+            value: $(params.RELEASE_TEST_TASKS_BRANCH)
+          - name: pathInRepo
+            value: .konflux/tekton/task-setup-testing-accounts.yaml
+      params:
+        - name: EAAS_SPACE_SECRET_REF
+          value: $(tasks.provision-eaas-space.results.secretRef)
+        - name: CLUSTER_NAME
+          value: $(tasks.provision-cluster.results.clusterName)
+        - name: IMAGE
+          value: $(params.IMAGE)
+      runAfter:
+        - install-pipelines-operator
+
     #Release Tests - Chains
     - name: release-tests-chains
       onError: continue
@@ -286,7 +324,7 @@ spec:
         - name: GIT_RELEASE_TESTS_BRANCH
           value: $(params.GIT_RELEASE_TESTS_BRANCH)
       runAfter:
-        - install-pipelines-operator
+        - setup-testing-accounts
 
     #Release Tests - Manual Approval Gate
     - name: release-tests-manual-approval
@@ -316,7 +354,7 @@ spec:
         - name: GIT_RELEASE_TESTS_BRANCH
           value: $(params.GIT_RELEASE_TESTS_BRANCH)
       runAfter:
-        - install-pipelines-operator
+        - setup-testing-accounts
 
     #Release Tests - Metrics
     - name: release-tests-metrics
@@ -346,7 +384,7 @@ spec:
         - name: GIT_RELEASE_TESTS_BRANCH
           value: $(params.GIT_RELEASE_TESTS_BRANCH)
       runAfter:
-        - install-pipelines-operator
+        - setup-testing-accounts
 
     #Release Tests - Pipelines as Code
     - name: release-tests-pac
@@ -376,7 +414,7 @@ spec:
         - name: GIT_RELEASE_TESTS_BRANCH
           value: $(params.GIT_RELEASE_TESTS_BRANCH)
       runAfter:
-        - install-pipelines-operator
+        - setup-testing-accounts
 
     #Release Tests - Versions
     - name: release-tests-versions
@@ -406,7 +444,7 @@ spec:
         - name: GIT_RELEASE_TESTS_BRANCH
           value: $(params.GIT_RELEASE_TESTS_BRANCH)
       runAfter:
-        - install-pipelines-operator
+        - setup-testing-accounts
 
     #Release Tests - Pipelines
     - name: release-tests-pipelines
@@ -436,7 +474,7 @@ spec:
         - name: GIT_RELEASE_TESTS_BRANCH
           value: $(params.GIT_RELEASE_TESTS_BRANCH)
       runAfter:
-        - install-pipelines-operator
+        - setup-testing-accounts
 
     #Release Tests - Triggers
     - name: release-tests-triggers
@@ -468,7 +506,7 @@ spec:
         - name: OCP_VERSION
           value: "$(tasks.provision-cluster.results.ocpVersion)"
       runAfter:
-        - install-pipelines-operator
+        - setup-testing-accounts
 
     #Release Tests - Results
     - name: release-tests-results
@@ -498,7 +536,7 @@ spec:
         - name: GIT_RELEASE_TESTS_BRANCH
           value: $(params.GIT_RELEASE_TESTS_BRANCH)
       runAfter:
-        - install-pipelines-operator
+        - setup-testing-accounts
 
     #Release Tests - Triggers TLS
     - name: release-tests-triggers-tls
@@ -528,7 +566,7 @@ spec:
         - name: GIT_RELEASE_TESTS_BRANCH
           value: $(params.GIT_RELEASE_TESTS_BRANCH)
       runAfter:
-        - install-pipelines-operator
+        - setup-testing-accounts
 
   finally:
     # Verify aggregate status and fail pipeline if any e2e task failed
@@ -545,11 +583,11 @@ spec:
             script: |
               #!/bin/sh
               echo "📋 Aggregate Status: $(params.aggregateStatus)"
-              
+
               if [[ "$(params.aggregateStatus)" != "Succeeded" ]]; then
                 echo "❌ Pipeline contains failed tasks!"
                 echo "💡 Check individual task logs for detailed error information"
                 exit 1
               fi
-              
+
               echo "✅ All tasks succeeded!"

--- a/.konflux/tekton/task-configure-loki-logging.yaml
+++ b/.konflux/tekton/task-configure-loki-logging.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: configure-loki-logging
+spec:
+  description: |
+    Installs MinIO, Loki operator, and OpenShift Logging operator on an
+    ephemeral EaaS cluster using the install-logging.sh script from the
+    release-tests-infra repository.
+  params:
+    - name: EAAS_SPACE_SECRET_REF
+      type: string
+    - name: CLUSTER_NAME
+      type: string
+      description: Name of the ephemeral EaaS cluster
+    - name: IMAGE
+      description: CI image that contains the oc client
+      default: quay.io/openshift-pipeline/ci:latest
+    - name: INFRA_REPO_URL
+      default: https://github.com/openshift-pipelines/release-tests-infra.git
+    - name: INFRA_REPO_BRANCH
+      default: acceptance-tests-infra
+  volumes:
+    - name: credentials
+      emptyDir: {}
+    - name: source
+      emptyDir: {}
+  stepTemplate:
+    image: $(params.IMAGE)
+    volumeMounts:
+      - name: credentials
+        mountPath: /credentials
+      - name: source
+        mountPath: /source
+  steps:
+    - name: create-repo
+      script: |
+        mkdir -p /source/infra
+        chmod 777 /source/infra
+    - name: fetch-infra-repo
+      ref:
+        resolver: http
+        params:
+          - name: url
+            value: https://raw.githubusercontent.com/openshift-pipelines/tektoncd-catalog/p/stepactions/stepaction-git-clone/0.4.1/stepaction-git-clone.yaml
+      params:
+        - name: OUTPUT_PATH
+          value: /source/infra
+        - name: URL
+          value: $(params.INFRA_REPO_URL)
+        - name: REVISION
+          value: $(params.INFRA_REPO_BRANCH)
+    - name: get-kubeconfig
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+      params:
+        - name: eaasSpaceSecretRef
+          value: "$(params.EAAS_SPACE_SECRET_REF)"
+        - name: clusterName
+          value: "$(params.CLUSTER_NAME)"
+        - name: credentials
+          value: credentials
+    - name: configure-loki-logging
+      env:
+        - name: KUBECONFIG
+          value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+      workingDir: /source/infra
+      script: |
+        #!/usr/bin/env bash
+        set -e -o pipefail
+
+        echo "Running install-logging.sh from release-tests-infra..."
+        echo "Cluster: $(oc whoami --show-server)"
+
+        chmod +x config/operators/install-logging.sh
+        bash config/operators/install-logging.sh
+
+        echo "Loki and Logging operators configured successfully!"

--- a/.konflux/tekton/task-e2e-pipeline.yaml
+++ b/.konflux/tekton/task-e2e-pipeline.yaml
@@ -121,6 +121,18 @@ spec:
               name: pac-gitlab
               key: gitlab-webhook-token
               optional: true
+        - name: GITLAB_GROUP_NAMESPACE
+          valueFrom:
+            secretKeyRef:
+              name: pac-gitlab
+              key: gitlab-group-ns
+              optional: true
+        - name: GITLAB_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: pac-gitlab
+              key: gitlab-project-id
+              optional: true
         - name: KUBECONFIG
           value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
         - name: CATALOG_SOURCE
@@ -135,11 +147,11 @@ spec:
         go mod download
         go build -p 1 ./...
         gauge config check_updates false
-        
+
         # Some of the tests fail on specific OCP versions
         set +H
         tags="$(params.TAGS),!(skip-$OCP_VERSION | to-do)"
         set -H
-        
+
         echo "Running $(params.SPECS) with tags $tags"
         gauge run --tags="$tags" --log-level=debug --verbose $(params.SPECS)

--- a/.konflux/tekton/task-setup-testing-accounts.yaml
+++ b/.konflux/tekton/task-setup-testing-accounts.yaml
@@ -1,0 +1,158 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: setup-testing-accounts
+spec:
+  description: |
+    Configures HTPasswd identity provider with standard test user accounts on an
+    ephemeral EaaS cluster.  Adapted from the plumbing repo task for Konflux,
+    where credentials come from the EaaS space secret rather than per-cluster
+    Kubernetes secrets.
+  params:
+    - name: EAAS_SPACE_SECRET_REF
+      type: string
+    - name: CLUSTER_NAME
+      type: string
+      description: Name of the ephemeral EaaS cluster
+    - name: IMAGE
+      description: CI image that contains the oc client
+      default: quay.io/openshift-pipeline/ci:latest
+  volumes:
+    - name: credentials
+      emptyDir: {}
+  stepTemplate:
+    image: $(params.IMAGE)
+    volumeMounts:
+      - name: credentials
+        mountPath: /credentials
+  steps:
+    - name: get-kubeconfig
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+      params:
+        - name: eaasSpaceSecretRef
+          value: "$(params.EAAS_SPACE_SECRET_REF)"
+        - name: clusterName
+          value: "$(params.CLUSTER_NAME)"
+        - name: credentials
+          value: credentials
+    - name: setup-testing-accounts
+      env:
+        - name: KUBECONFIG
+          value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+      script: |
+        #!/usr/bin/env bash
+        set -e -u -o pipefail
+
+        echo "Setting up testing accounts on ephemeral EaaS cluster..."
+        echo "Cluster: $(oc whoami --show-server)"
+
+        # Build htpasswd file
+        USERS=(
+          "consoledeveloper:developer"
+          "pipelinesdeveloper:developer"
+          "user:user"
+        )
+        for i in $(seq 1 9); do
+          USERS+=("user${i}:user${i}")
+        done
+
+        HTPASSWD_FILE=$(mktemp)
+        for entry in "${USERS[@]}"; do
+          username="${entry%%:*}"
+          password="${entry#*:}"
+          if command -v htpasswd &>/dev/null; then
+            if [ ! -s "$HTPASSWD_FILE" ]; then
+              htpasswd -cbB "$HTPASSWD_FILE" "$username" "$password"
+            else
+              htpasswd -bB "$HTPASSWD_FILE" "$username" "$password"
+            fi
+          elif command -v openssl &>/dev/null; then
+            echo "${username}:$(openssl passwd -apr1 "$password")" >> "$HTPASSWD_FILE"
+          else
+            echo "ERROR: neither htpasswd nor openssl found in image" >&2
+            exit 1
+          fi
+        done
+
+        echo "Created htpasswd file with $(wc -l < "$HTPASSWD_FILE") user(s)"
+
+        # Create htpasswd secret
+        oc create secret generic htpass-secret \
+          --from-file=htpasswd="$HTPASSWD_FILE" \
+          -n openshift-config \
+          --dry-run=client -o yaml | oc apply -f-
+
+        # Configure OAuth identity provider
+        cat <<'EOF' | oc apply -f-
+        apiVersion: config.openshift.io/v1
+        kind: OAuth
+        metadata:
+          name: cluster
+        spec:
+          identityProviders:
+          - name: htpasswd-provider
+            mappingMethod: claim
+            type: HTPasswd
+            htpasswd:
+              fileData:
+                name: htpass-secret
+        EOF
+
+        # Wait for OAuth rollout
+        echo "Waiting for OAuth server to reconcile new configuration..."
+        sleep 10
+        oc wait co/authentication --for=condition=Progressing=False --timeout=300s || true
+        oc wait co/authentication --for=condition=Available=True --timeout=300s
+
+        # Assign cluster roles
+        echo "Assigning cluster roles..."
+        oc adm policy add-cluster-role-to-user self-provisioner consoledeveloper
+        oc adm policy add-cluster-role-to-user view consoledeveloper
+        oc adm policy add-cluster-role-to-user basic-user pipelinesdeveloper
+
+        # ── 6. Verify a test user can authenticate ──────────────────────
+        echo "Verifying user authentication (may take a few minutes)..."
+        VERIFY_KUBECONFIG=$(mktemp)
+        API_SERVER=$(oc whoami --show-server)
+        VERIFIED=false
+        for attempt in $(seq 1 30); do
+          if KUBECONFIG="$VERIFY_KUBECONFIG" oc login -u user -p user \
+                "$API_SERVER" --insecure-skip-tls-verify=true &>/dev/null; then
+            echo "User authentication verified on attempt $attempt"
+            VERIFIED=true
+            break
+          fi
+          echo "Attempt $attempt/30: OAuth not ready yet, retrying in 10s..."
+          sleep 10
+        done
+        rm -f "$VERIFY_KUBECONFIG"
+
+        if [ "$VERIFIED" = "false" ]; then
+          echo "ERROR: user authentication verification failed after 5 minutes" >&2
+          exit 1
+        fi
+
+        # Summary
+        echo ""
+        echo "Testing accounts configured successfully!"
+        echo ""
+        echo "Username           | Password                | Cluster roles"
+        echo "-------------------|-----------------------------------------"
+        echo "consoledeveloper   | developer               | self-provisioner, view"
+        echo "pipelinesdeveloper | developer               | basic-user"
+        echo "user               | user                    | default"
+        for i in $(seq 1 9); do
+          printf "user%-14s | user%-20s | default\n" "$i" "$i"
+        done
+        echo "-------------------------------------------------------------"
+
+        rm -f "$HTPASSWD_FILE"


### PR DESCRIPTION
## Description
The release-tests have been failing at the cluster-provision task with a timeout issue.
This is a WIP branch to fix the release-tests

## Test Matrix

| # | FIPS | IDMS | Timeout | Commit | Result | PipelineRun |
|---|------|------|---------|---------|--------|------|
| 1 | true | yes | 60m | 71ef67bdb | ❗ Timeout - identical status as 30m| [akshay-osp-index-4-21-1-21-release-tests-amd64-f89k2](https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/tekton-ecosystem-tenant/applications/openshift-pipelines-index-4-21-1-21/pipelineruns/akshay-osp-index-4-21-1-21-release-tests-amd64-f89k2/) |
| 2 | false | no | 60m | a870550cb | ✅ Cluster provisioning successful| [akshay-osp-index-4-21-1-21-release-tests-amd64-xbcv9](https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/tekton-ecosystem-tenant/applications/openshift-pipelines-index-4-21-1-21/pipelineruns/akshay-osp-index-4-21-1-21-release-tests-amd64-xbcv9/logs)  |
| 3 | true | no | 60m | b2ee275d0 | ✅ Cluster provisioning successful | [akshay-osp-index-4-21-1-21-release-tests-amd64-vbw4l](https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/tekton-ecosystem-tenant/applications/openshift-pipelines-index-4-21-1-21/pipelineruns/akshay-osp-index-4-21-1-21-release-tests-amd64-vbw4l/logs) |
| 4 | false | yes | 60m | 5d596c558 | ❗ Timeout - identical status as earlier| [akshay-osp-index-4-21-1-21-release-tests-amd64-9rqhg](https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/tekton-ecosystem-tenant/applications/openshift-pipelines-index-4-21-1-21/pipelineruns/akshay-osp-index-4-21-1-21-release-tests-amd64-9rqhg) |