### PR TITLE
chore: update project.yaml with correct snapshot SHAs

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -106,7 +106,7 @@ images:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:4e7c197c1f328cf8dbd6455647b137725495b0dfbe32ec2d640caadce0486523
   # console-plugin
   - name: IMAGE_PIPELINES_CONSOLE_PLUGIN
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-console-plugin-rhel9@sha256:dd1e98d6f10b2899ed40c90ce6a85a31ad2aa1b6f81b0752ee90d4489ea13dc5
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-console-plugin-rhel9@sha256:3421bd117b9b27a40bc0ff8916a1b608c34a6dcd3ee1809a380bea7ace8cc581
   - name: IMAGE_PIPELINES_CONSOLE_PLUGIN_LEGACY
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-console-plugin-pf5-rhel9@sha256:36dc4278b27549b0c36459b90c8047767628b672869508bf2817b357f9925e88
   # OPC
@@ -127,4 +127,4 @@ images:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-multicluster-proxy-aae-rhel9@sha256:0501e33fd58d00c4693597a1afefc75749837b70276b0e8d0c0fa994583299ea
   #Syncer Service Workload Controller
   - name: IMAGE_SYNCER_SERVICE_WORKLOAD_CONTROLLER
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-syncer-service-rhel9@sha256:0cc514e6f361a2327133082536d59824db409d873470e5251e7582d500a3ef71
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-syncer-service-rhel9@sha256:e121d6520504c2b2724f268da42b1111f3b1c5cf6613b996a5183e3ab14bcaaf


### PR DESCRIPTION
Update console-plugin and syncer-service image SHAs to match the released core snapshot openshift-pipelines-core-1-23-20260711-083843-000.