### PR TITLE
Add fbc-inject-lifecycle task to FBC pipeline

### DIFF
--- a/.tekton/fbc-build.yaml
+++ b/.tekton/fbc-build.yaml
@@ -178,12 +178,35 @@ spec:
     workspaces:
     - name: basic-auth
       workspace: git-auth
+  - name: fbc-inject-lifecycle
+    params:
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).lifecycle
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - clone-repository
+    taskRef:
+      params:
+      - name: name
+        value: fbc-inject-lifecycle-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-inject-lifecycle-oci-ta:0.1@sha256:9b6d61e5e887a8f30940c1fed0e118b8974c382d0a6328db99705a44365f6b0b
+      - name: kind
+        value: task
+      resolver: bundles
   - name: prefetch-dependencies
     params:
     - name: input
       value: $(params.prefetch-input)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      value: $(tasks.fbc-inject-lifecycle.results.SOURCE_ARTIFACT)
     - name: ociStorage
       value: $(params.output-image).prefetch
     - name: ociArtifactExpiresAfter
@@ -191,7 +214,7 @@ spec:
     - name: enable-package-registry-proxy
       value: $(params.enable-package-registry-proxy)
     runAfter:
-    - clone-repository
+    - fbc-inject-lifecycle
     taskRef:
       params:
       - name: name


### PR DESCRIPTION
Add fbc-inject-lifecycle task to FBC build pipeline.

`openshift-pipelines-operator-rh` was selected as a pilot operator for the Operator Upgrade Planner OCP 5.0 release-blocking feature. We would like help building the **5.0 FBC** and doing a **stage release** for it. We will verify the build and stage release from our end to confirm it meets our expectations.

Using the [plcc2fbc tool](https://github.com/release-engineering/fbc-update-planner), the task fetches lifecycle data for `openshift-pipelines-operator-rh` from the PLCC API, validates it, and converts it from PLCC format to FBC. After that, the task injects lifecycle.json into the 5.0 catalog. The lifecycle data is then displayed on the Console UI.

This is a failure case: since the `openshift-pipelines-operator-rh` lifecycle data fails validation, no injection will happen.

Feature JIRA: https://redhat.atlassian.net/browse/OCPSTRAT-2618 https://redhat.atlassian.net/browse/KONFLUX-12579
This E2E test JIRA: https://redhat.atlassian.net/browse/CLOUDDST-32594