### PR TITLE
fix: revert incorrect PAC payload path introduced by 1.22 sync

### DIFF
--- a/hack/operator-fetch-payload.sh
+++ b/hack/operator-fetch-payload.sh
@@ -160,7 +160,7 @@ env SERVE_REF="$SERVE_REF" yq e -i '
 
 # Mutate pipelines-as-code payload
 for d in controller watcher webhook; do
-    yq e -i "(select (.kind == \"Deployment\") | select (.metadata.name == \"pipelines-as-code-${d}\") | .spec.template.spec.containers[0].command) = [\"/ko-app/pipelines-as-code-${d}\"]" .konflux/olm-catalog/bundle/kodata/tekton-addon/pipelines-as-code/*/release.yaml
+    yq e -i "(select (.kind == \"Deployment\") | select (.metadata.name == \"pipelines-as-code-${d}\") | .spec.template.spec.containers[0].command) = [\"/ko-app/pipelines-as-code-${d}\"]" .konflux/olm-catalog/bundle/kodata/pipelines-as-code/*/release.yaml
 done
 
 # Mutate manual-approval-gate payload


### PR DESCRIPTION
The sync from release-v1.22.x (d74b2c32) introduced a path regression in operator-fetch-payload.sh:

- PAC payload path: 1.23 uses kodata/pipelines-as-code/ (not kodata/tekton-addon/pipelines-as-code/ as in 1.22)

This broke the update-sources workflow since Jul 14.