### PR TITLE
revert project.yaml image SHAs to match core snapshot

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -9,23 +9,23 @@ versions:
 images:
   # tektoncd-pipeline
   - name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-controller-rhel9@sha256:584ef7fbb128f3c65949df35f0989bd1d1a016b524df9e4d982bdf08f0bd4076
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-controller-rhel9@sha256:bb91f63a065c64561189f386c16529531c420108621dc454254c2b0c3eaa9751
   - name: IMAGE_PIPELINES_WEBHOOK
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-webhook-rhel9@sha256:abb61b2bf1f18540a7795c2e057efb28e54cc6e4940b7533eb8f83010d835988
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-webhook-rhel9@sha256:92cdae1d178d743413e1a7b96697dec83f0640f02930f8f948bfa076c01690e8
   - name: IMAGE_PIPELINES_CONTROLLER # should be RESOLVERS instead
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-resolvers-rhel9@sha256:32a1b48bed17021eee0f2eeaecc7c57afba131a7ce314eafc0617ac62579822e
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-resolvers-rhel9@sha256:df840c0c0a6aa9039e46710df2b4358c445e12ac570f2469f9dd9c69fefec00f
   - name: IMAGE_PIPELINES_TEKTON_EVENTS_CONTROLLER
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-events-rhel9@sha256:45f51f0dad382b73e28ffc9f3b0ff64419ab4570fcb87fdc100f3245c8ca8bb9
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-events-rhel9@sha256:05a5dd9ab1a6907bfe6f500829b06ebf04c09f406221da7a57c05ee86f1264a6
   - name: IMAGE_PIPELINES_ARG__ENTRYPOINT_IMAGE
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-entrypoint-rhel9@sha256:5d95f8b9e3a764bdb381d2fc0be6a0433d71b9233aaec3bc6e5afb828ac965dd
   - name: IMAGE_PIPELINES_ARG__WORKINGDIRINIT_IMAGE
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-workingdirinit-rhel9@sha256:df92334225cf81f7da31b705c8bfa3228891e966480a5dd186ec71fa1bc186d4
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-workingdirinit-rhel9@sha256:de638815257d462fde7906ee3edb520c003e8efc423dffa680c467d04ba2162d
   - name: IMAGE_PIPELINES_ARG__NOP_IMAGE
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-nop-rhel9@sha256:4f727827392c65835ec312337353fa12ed923da53fa876cf802d3c2608ff419c
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-nop-rhel9@sha256:70534e3edce1f91afae59d708c9dd5ac8df3ff474a903f614879eb8db2115cb1
   - name: IMAGE_PIPELINES_ARG__SHELL_IMAGE
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-entrypoint-rhel9@sha256:5d95f8b9e3a764bdb381d2fc0be6a0433d71b9233aaec3bc6e5afb828ac965dd
   - name: IMAGE_PIPELINES_ARG__SIDECARLOGRESULTS_IMAGE
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-sidecarlogresults-rhel9@sha256:7a638878b8f8c31e902dc72fd7a9f0c8e6e8ccf71c80cacc621f4d91c47cd9d1
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-sidecarlogresults-rhel9@sha256:4a5b0d21d29eeb652f162f4830e37f529a76b2f97a2b1262a307a7977fc1aab7
   # tektoncd-triggers
   - name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CONTROLLER
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-triggers-controller-rhel9@sha256:133f06b2a23785e183a01be9500285f41f39c155c5fb634f7e6cc3f326c72d58
@@ -37,28 +37,28 @@ images:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-triggers-eventlistenersink-rhel9@sha256:cf4b526dfa747a451b03dd4e8d2c76572dfbe0042bbbe328c839e82691c459c6
   # tektoncd-chains
   - name: IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-chains-controller-rhel9@sha256:c9d84a9813911e69a22eff4e87a2879027b560a28fdbccaf287b381ee8a8fd44
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-chains-controller-rhel9@sha256:029967f2517fad04613887e77377fabbc0a5a811ebd1e4f307da13be9f08b70a
   # tektoncd-hub
   - name: IMAGE_HUB_TEKTON_HUB_DB_MIGRATION
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-hub-db-migration-rhel9@sha256:ee308ef1030e1e3c95a23d4b13759d8faaad4b99f4ea3c0d1478c85f2d62eb32
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-hub-db-migration-rhel9@sha256:fc1d068fe8c52d967cf2b260b54b83e94a599137d6a80b5e1cd66f0491294d7d
   - name: IMAGE_HUB_TEKTON_HUB_API
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-hub-api-rhel9@sha256:675faf1cb5a72b7d5f6f613817ef1e8c6d7a5ea1194b8ef7b0c24b4abee92035
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-hub-api-rhel9@sha256:abc55764d7d29464ca9824f206e030d2631f38d0ab14763226f1eeee8da05620
   - name: IMAGE_HUB_TEKTON_HUB_UI
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-hub-ui-rhel9@sha256:064d9be82cd294db53ee2fca09e34caf644157db85910668eeefddbbb41d0b86
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-hub-ui-rhel9@sha256:d0071b484048aac2d6fc3d625bbdbd98d09aea82649752dd4c3854e73b7062b4
   # tektoncd-results
   - name: IMAGE_RESULTS_WATCHER
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-results-watcher-rhel9@sha256:5523edd8bd8461e4538cbb146339427556a45f1ad814be6e6d076ab718992fc9
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-results-watcher-rhel9@sha256:358ba2ca6138859fc08043fc3164e6535edd2d7c1d5550ae4d301ab2d088088b
   - name: IMAGE_RESULTS_API
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-results-api-rhel9@sha256:647cfdbb4736e65d1bc35aa0230cc6c01d3e3c983cf168af98f49f094a2bc17d
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-results-api-rhel9@sha256:9c96f5e78d6cdb42844a03a48f20d093e1843964bec44b999e5c4bcd76e7fe2f
   - name: IMAGE_RESULTS_RETENTION_POLICY_AGENT
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-results-retention-policy-agent-rhel9@sha256:08e35d567e32b3c859240d7a7bed20023bf6297d50e22f7eaa98885256a40474
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-results-retention-policy-agent-rhel9@sha256:fc660bf75a82227cd7d918e652455b42da5bbbe2d170d8fbebc9c4fc7135f77d
   # tektoncd-cli
   - name: IMAGE_JOB_PRUNER_TKN
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cli-tkn-rhel9@sha256:00154404ba2131428a5522d39613baf1c96b613c8bd5367e95eb3acb446000f2
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cli-tkn-rhel9@sha256:da6ad50598165c738cf5c32d2118af509922fca62529d800eae1ed5748f15259
   - name: IMAGE_ADDONS_PARAM_TKN_IMAGE
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cli-tkn-rhel9@sha256:00154404ba2131428a5522d39613baf1c96b613c8bd5367e95eb3acb446000f2
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cli-tkn-rhel9@sha256:da6ad50598165c738cf5c32d2118af509922fca62529d800eae1ed5748f15259
   - name: IMAGE_ADDONS_TKN
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cli-tkn-rhel9@sha256:00154404ba2131428a5522d39613baf1c96b613c8bd5367e95eb3acb446000f2
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cli-tkn-rhel9@sha256:da6ad50598165c738cf5c32d2118af509922fca62529d800eae1ed5748f15259
   - name: IMAGE_ADDONS_TKN_CLI_SERVE # FIXME: we need to figure how to manage this in konflux. For now, using released version (1.16)
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-serve-tkn-cli-rhel9@sha256:6291014ba112469811daf87f584034896662d782e16b35ba70e07ca02456b3b1
   - name: IMAGE_ADDONS_TKN_CLI_SERVE_INIT_CONFIG
@@ -79,31 +79,31 @@ images:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-pipelines-as-code-cli-rhel9@sha256:f74ef7ecd77606f5f9533fb23f05de4f28265342871f5abfe2d1182c50e001ea
   # operator
   - name: OPENSHIFT_PIPELINES_OPERATOR_LIFECYCLE
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-rhel9-operator@sha256:aa85c14209541dd45a719321aed43eae26d60269978f6a04420e7a1f84a591f3
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-rhel9-operator@sha256:dcb216d74d476dc7fbf07175aa1fcea24b43f7f86f51ed6e43e8ceb91424fb58
   - name: OPENSHIFT_PIPELINES_OPERATOR_CLUSTER_OPERATIONS
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-rhel9-operator@sha256:aa85c14209541dd45a719321aed43eae26d60269978f6a04420e7a1f84a591f3
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-rhel9-operator@sha256:dcb216d74d476dc7fbf07175aa1fcea24b43f7f86f51ed6e43e8ceb91424fb58
   - name: IMAGE_PIPELINES_PROXY
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-operator-proxy-rhel9@sha256:165e2648bb6ba5d1107e49f7039b2827d49ff44be49fcfc348165973ca10707e
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-operator-proxy-rhel9@sha256:6e4b1be21a3ccf0c6350e3e7c0d1e1687153271a5a535fb7f94d9ec141d7e4c8
   - name: TEKTON_OPERATOR_WEBHOOK
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-operator-webhook-rhel9@sha256:686558e7f247aa3fc220e2f10590c59f46ab545484f7db7e213334e877fb770e
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-operator-webhook-rhel9@sha256:f76d0c26c09068f6ed5f932a7d96d976ef8ca5bd3d36692a84e018cb5136b6d4
   # cache
   - name: IMAGE_ADDONS_CACHE_UPLOAD
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cache-rhel9@sha256:99de3fcf997a1fda03cff70fa3cf559f43f214ee569a9d0c8bc14e5e7a9cc7b6
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cache-rhel9@sha256:31c86cf5604cdefe8c0fa0646c05fae93a6281699295affcc8ff05d986f3a616
   - name: IMAGE_ADDONS_CACHE_FETCH
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cache-rhel9@sha256:99de3fcf997a1fda03cff70fa3cf559f43f214ee569a9d0c8bc14e5e7a9cc7b6
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cache-rhel9@sha256:31c86cf5604cdefe8c0fa0646c05fae93a6281699295affcc8ff05d986f3a616
   # Addons
   - name: IMAGE_PIPELINES_ARG__GIT_IMAGE
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:a03369d14d7f25e87ecb3e413748226938f8668ca42daeeba32021a994b18b90
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:4e7c197c1f328cf8dbd6455647b137725495b0dfbe32ec2d640caadce0486523
   - name: IMAGE_ADDONS_PARAM_GITINITIMAGE
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:a03369d14d7f25e87ecb3e413748226938f8668ca42daeeba32021a994b18b90
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:4e7c197c1f328cf8dbd6455647b137725495b0dfbe32ec2d640caadce0486523
   - name: IMAGE_ADDONS_GIT_RUN
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:a03369d14d7f25e87ecb3e413748226938f8668ca42daeeba32021a994b18b90
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:4e7c197c1f328cf8dbd6455647b137725495b0dfbe32ec2d640caadce0486523
   - name: IMAGE_ADDONS_REPORT
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:a03369d14d7f25e87ecb3e413748226938f8668ca42daeeba32021a994b18b90
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:4e7c197c1f328cf8dbd6455647b137725495b0dfbe32ec2d640caadce0486523
   - name: IMAGE_ADDONS_GIT_CLONE
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:a03369d14d7f25e87ecb3e413748226938f8668ca42daeeba32021a994b18b90
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:4e7c197c1f328cf8dbd6455647b137725495b0dfbe32ec2d640caadce0486523
   - name: IMAGE_ADDONS_PREPARE_AND_RUN
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:a03369d14d7f25e87ecb3e413748226938f8668ca42daeeba32021a994b18b90
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:4e7c197c1f328cf8dbd6455647b137725495b0dfbe32ec2d640caadce0486523
   # console-plugin
   - name: IMAGE_PIPELINES_CONSOLE_PLUGIN
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-console-plugin-rhel9@sha256:c06b4ec0b7f199aebbf45e24ae158930e2d57f7331c0d05325273525731c1b80
@@ -114,9 +114,9 @@ images:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-opc-rhel9@sha256:ed9a52d7e32acbdb791eacd73c936ef26baf277fd801af8965c8af0987fdacd7
   # Pruner
   - name: IMAGE_PRUNER_CONTROLLER
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-pruner-controller-rhel9@sha256:5d6d1bff167a9780803fec94671ae91757d773d60901e83d48304a219f3f8d7d
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-pruner-controller-rhel9@sha256:5b6ec6ce4c31bfa25ec153b4a9246a696c3d77b293613eb1bdb3bbbe24da247d
   - name: IMAGE_PRUNER_WEBHOOK
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-pruner-webhook-rhel9@sha256:d208dddd6a06ad542a23e384458b3b019e0baeb74e02ecd54bd6991b525e219e
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-pruner-webhook-rhel9@sha256:13d5453f6d59cecaa8f583d757cc43a1c16c08eedb8d354fe1af8251ea650034
   # Scheduler
   - name: IMAGE_SCHEDULER_MANAGER
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-scheduler-rhel9@sha256:f2a7aa27ea223fae0fde258a21f132efa9bf07449b62cd05880c0caf5308c753


### PR DESCRIPTION
Revert 31 image references to match the core snapshot openshift-pipelines-core-1-23-20260714-071901-000 used for stage and production releases.