### PR TITLE
[release-v1.15.x] Update all component image digests for 1.15.5

### DIFF
--- a/.konflux/olm-catalog/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/.konflux/olm-catalog/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -1176,9 +1176,9 @@ spec:
                       - name: OPERATOR_NAME
                         value: redhat-openshift-pipelines-operator
                       - name: IMAGE_PIPELINES_PROXY
-                        value: quay.io/openshift-pipeline/pipelines-operator-proxy-rhel8@sha256:0e2710179ec9b9d905593b4c180cad6d49dbeceb1b6a1930d9957ca32e1f9e3a
+                        value: quay.io/openshift-pipeline/pipelines-operator-proxy-rhel8@sha256:bc7afb441d2179f6ba40d44883d25ef7b80d2a4c12f4d8b7e9a6ea374e24e332
                       - name: IMAGE_JOB_PRUNER_TKN
-                        value: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:6bd9ec5e20d563207fd11de6d4609daacfc770d33b4b0b98c0bd7d9e6c6017b0
+                        value: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:3b4811317fd2c76d9fd403b2a499d90656423de571f785ee35da670f0fed8962
                       - name: METRICS_DOMAIN
                         value: tekton.dev/operator
                       - name: VERSION
@@ -1216,37 +1216,37 @@ spec:
                       - name: IMAGE_ADDONS_OC
                         value: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                       - name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
-                        value: quay.io/openshift-pipeline/pipelines-controller-rhel8@sha256:94d5b387d143839d35b20e74a64531952c5651cf3b3916315b5510f06d1945a6
+                        value: quay.io/openshift-pipeline/pipelines-controller-rhel8@sha256:d3e64dc90eec6e54112aeb34f17e7155b9351c9850fae644725bd291be93d31c
                       - name: IMAGE_PIPELINES_WEBHOOK
-                        value: quay.io/openshift-pipeline/pipelines-webhook-rhel8@sha256:d2e8a562e8d8893917dcfac6380b248d2b195dffd898ded367f2f4e7620286d0
+                        value: quay.io/openshift-pipeline/pipelines-webhook-rhel8@sha256:f33e348c06ce4a91610958fb037457731a54f8b53a0b52f32f4e8484bfe4cd40
                       - name: IMAGE_PIPELINES_CONTROLLER
-                        value: quay.io/openshift-pipeline/pipelines-resolvers-rhel8@sha256:ab451765e0e07bb52be8fa66abb1045d5c7908abf4fc8c497df4afffd4be34d3
+                        value: quay.io/openshift-pipeline/pipelines-resolvers-rhel8@sha256:9fb0259ef015dba90afdf695c428bb0652f6f640d38cf801ba70b4c8f3e143d4
                       - name: IMAGE_PIPELINES_TEKTON_EVENTS_CONTROLLER
-                        value: quay.io/openshift-pipeline/pipelines-events-rhel8@sha256:3e31d38394e05559671bfef4dd8446d74e379389a30016d48cc4a0b22d45a775
+                        value: quay.io/openshift-pipeline/pipelines-events-rhel8@sha256:1bfab940282d8af8377a5cc34beb4ae18a027f971b80231f9382b3128772225c
                       - name: IMAGE_PIPELINES_ARG__ENTRYPOINT_IMAGE
-                        value: quay.io/openshift-pipeline/pipelines-entrypoint-rhel8@sha256:815e3f780e1b0171ede74a5ab974d360ab6542dd80fdafd3d03c836395b3d80c
+                        value: quay.io/openshift-pipeline/pipelines-entrypoint-rhel8@sha256:48ace5a1685b16f343378112a612f0c70a2fd4bbc5e3d5f558310dfc826430c8
                       - name: IMAGE_PIPELINES_ARG__GIT_IMAGE
-                        value: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:043080bff45cd129c0852b55a578c1a85e8911de80fadef22a21a034a1eccd56
+                        value: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:04f5c5f9b8a5e3642e4994790324c92c7ecb4a1562823d71254b60b7ebc671cb
                       - name: IMAGE_ADDONS_PARAM_GITINITIMAGE
-                        value: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:043080bff45cd129c0852b55a578c1a85e8911de80fadef22a21a034a1eccd56
+                        value: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:04f5c5f9b8a5e3642e4994790324c92c7ecb4a1562823d71254b60b7ebc671cb
                       - name: IMAGE_ADDONS_GIT_RUN
-                        value: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:043080bff45cd129c0852b55a578c1a85e8911de80fadef22a21a034a1eccd56
+                        value: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:04f5c5f9b8a5e3642e4994790324c92c7ecb4a1562823d71254b60b7ebc671cb
                       - name: IMAGE_ADDONS_REPORT
-                        value: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:043080bff45cd129c0852b55a578c1a85e8911de80fadef22a21a034a1eccd56
+                        value: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:04f5c5f9b8a5e3642e4994790324c92c7ecb4a1562823d71254b60b7ebc671cb
                       - name: IMAGE_PIPELINES_ARG__WORKINGDIRINIT_IMAGE
-                        value: quay.io/openshift-pipeline/pipelines-workingdirinit-rhel8@sha256:1a668bdf91a8127fde8c43593749f51ded53a0fbed551fab1c22b51483135205
+                        value: quay.io/openshift-pipeline/pipelines-workingdirinit-rhel8@sha256:69cb27dd7ddf41f054893b51f1bf5292c2711f1d0bec051d52febf77c37411ab
                       - name: IMAGE_PIPELINES_ARG__NOP_IMAGE
-                        value: quay.io/openshift-pipeline/pipelines-nop-rhel8@sha256:7c89565b0b580cfbdec22bdc5d6c6bc46af4512fd96ce8c49dc3dcad32273080
+                        value: quay.io/openshift-pipeline/pipelines-nop-rhel8@sha256:34ed012539ea11b008e1c0143a9e8ce1efbeccc7e54e20c2929e99993f5e94c9
                       - name: IMAGE_PIPELINES_ARG__SHELL_IMAGE
-                        value: quay.io/openshift-pipeline/pipelines-entrypoint-rhel8@sha256:d7884d6fffd18f8810bf30798d057dac3c0366821a71e5dbe6ede14c0d11859b
+                        value: quay.io/openshift-pipeline/pipelines-entrypoint-rhel8@sha256:48ace5a1685b16f343378112a612f0c70a2fd4bbc5e3d5f558310dfc826430c8
                       - name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CONTROLLER
                         value: quay.io/openshift-pipeline/pipelines-triggers-controller-rhel8@sha256::81a78829a209a007182f0cd0002538fb1b5797c9877f7f4b6fa1289ba74d2698
                       - name: IMAGE_TRIGGERS_WEBHOOK
-                        value: quay.io/openshift-pipeline/pipelines-triggers-webhook-rhel8@sha256:387059126e53effe723c98f55fcc8ea1805919539e1e1841d09e96e306891cf9
+                        value: quay.io/openshift-pipeline/pipelines-triggers-webhook-rhel8@sha256:6d004404d43e31fc27be43f84ba1429e7ad2060c0d8c50a5d08296d1269b58b3
                       - name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CORE_INTERCEPTORS
-                        value: quay.io/openshift-pipeline/pipelines-triggers-core-interceptors-rhel8@sha256:3431fadcdb3d872b083df2a17ff083dcf6c90a13e5c6dd717d09072d2a37a041
+                        value: quay.io/openshift-pipeline/pipelines-triggers-core-interceptors-rhel8@sha256:e9417bd2679360504c31f26bdaf1b4b724716cacb4d7f0060282375fe4ab3161
                       - name: IMAGE_TRIGGERS_ARG__EL_IMAGE
-                        value: quay.io/openshift-pipeline/pipelines-triggers-eventlistenersink-rhel8@sha256:9d0858b819cf2c739dd9783bd47c5f9e8df35c806b295ae62fbb985d52bf52b8
+                        value: quay.io/openshift-pipeline/pipelines-triggers-eventlistenersink-rhel8@sha256:0c5d68846bf897e3af5d7b147ed41448bdc99012b33df3662b54b361ff3b20c4
                       - name: IMAGE_ADDONS_KN
                         value: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:bf6cf2e87fb19f7aa9a490b83c16af69834c0721220a643710a1b077959e91ca
                       - name: IMAGE_ADDONS_SKOPEO_RESULTS
@@ -1264,40 +1264,40 @@ spec:
                       - name: IMAGE_ADDONS_PREPARE
                         value: registry.redhat.io/ubi8/ubi-minimal@sha256:f729a7f5685ea823e87ffd68aff988f2b8ff8d52126ade4e6de7c68088f28ebd
                       - name: IMAGE_ADDONS_PARAM_TKN_IMAGE
-                        value: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:6bd9ec5e20d563207fd11de6d4609daacfc770d33b4b0b98c0bd7d9e6c6017b0
+                        value: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:3b4811317fd2c76d9fd403b2a499d90656423de571f785ee35da670f0fed8962
                       - name: IMAGE_ADDONS_TKN
-                        value: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:6bd9ec5e20d563207fd11de6d4609daacfc770d33b4b0b98c0bd7d9e6c6017b0
+                        value: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:3b4811317fd2c76d9fd403b2a499d90656423de571f785ee35da670f0fed8962
                       - name: IMAGE_ADDONS_TKN_CLI_SERVE
-                        value: quay.io/openshift-pipeline/pipelines-serve-tkn-cli-rhel8@sha256:06a6c9d2f12f9446342c407e0ee6caa397d0ed4f6eefdd4c9c58f08fc98f62a5
+                        value: quay.io/openshift-pipeline/pipelines-serve-tkn-cli-rhel8@sha256:8eae5cd9e6cbd7a5956d2563112af9809c8482a2c5aba49bd9641aa3e50fb8cd
                       - name: IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
-                        value: quay.io/openshift-pipeline/pipelines-chains-controller-rhel8@sha256:fb31538fc07b36c9fc5064d7a3d4aeb1eed85aae7e340276d3f5de3f02c5985b
+                        value: quay.io/openshift-pipeline/pipelines-chains-controller-rhel8@sha256:0da4bbcaf1d77867eae57f1469a4ea32869a71d0d762130400df40e35d683945
                       - name: IMAGE_RESULTS_POSTGRES
                         value: registry.redhat.io/rhel8/postgresql-13@sha256:a92a579f1aef66ac188d24fd489c456a1a3e311d95dcce652da6b81e28fbf725
                       - name: IMAGE_HUB_TEKTON_HUB_DB_MIGRATION
-                        value: quay.io/openshift-pipeline/pipelines-hub-db-migration-rhel8@sha256:a803aca992f753d18e58c78f870b6e9c7b7a8d85ed042f74cdd27f22daf52d6d
+                        value: quay.io/openshift-pipeline/pipelines-hub-db-migration-rhel8@sha256:e9c37606a18e2f44487b1f68ffb12fa58fe2dc2d74bee7f71d17ce98aedfeee3
                       - name: IMAGE_HUB_TEKTON_HUB_API
-                        value: quay.io/openshift-pipeline/pipelines-hub-api-rhel8@sha256:241a99927f470f2ffd2cbdb6696e22a50192618d428e4d4a8a6b131cf81c9377
+                        value: quay.io/openshift-pipeline/pipelines-hub-api-rhel8@sha256:c8a83262ce2001d086d7ac9e8eb15112dbcae696ce16c950b9c0d7b683c4eb31
                       - name: IMAGE_HUB_TEKTON_HUB_UI
-                        value: quay.io/openshift-pipeline/pipelines-hub-ui-rhel8@sha256:da30e1731eae77f655a60d18816b8afe837cd699f17c56621db5f681806cfdfd
+                        value: quay.io/openshift-pipeline/pipelines-hub-ui-rhel8@sha256:a8d7ab30b5f0dd0319dcbcafde2a6366bace47c6f87698d16c1270af420eb47b
                       - name: IMAGE_MAG_TEKTON_TASKGROUP_CONTROLLER
-                        value: quay.io/openshift-pipeline/pipelines-manual-approval-gate-controller-rhel8@sha256:7c7c0414eaea222b247e3620a0162b94510296bd781401bcf7dfee1639d0e956
+                        value: quay.io/openshift-pipeline/pipelines-manual-approval-gate-controller-rhel8@sha256:9e01c4652508dd646568e646e45fd50a9c3ec846a2bececca1e26ea82aacbb22
                       - name: IMAGE_MAG_MANUAL_APPROVAL
-                        value: quay.io/openshift-pipeline/pipelines-manual-approval-gate-webhook-rhel8@sha256:1dcf60ed244bc0d37b6472a3614e1d6c1a9ebe7ef1a06c492d5bde2eba2f4af0
+                        value: quay.io/openshift-pipeline/pipelines-manual-approval-gate-webhook-rhel8@sha256:700b8f1c84d23ff28cbcaa84bb3d00187d3fc4f88800d6ea4c239477dc41c3e2
                       - name: IMAGE_PAC_PAC_CONTROLLER
-                        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel8@sha256:c7c216cb0ed3c163a4f9eeefd2bbbc20ebee28b8235eb51a9209443ba493f998
+                        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel8@sha256:66ca20713c84f4775a788d2839f0126ab4c149f62b9fe28fd4c694c941c22dfa
                       - name: IMAGE_PAC_PAC_WEBHOOK
-                        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel8@sha256:52825b01b2fea296caa58bea3e1195b1e40c1eaa5f6ae10192d2537897ca505c
+                        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel8@sha256:9e88266973bcdccc4e61d1dedc272704c3bd76a5d388d97c0ab325cc2431ac2b
                       - name: IMAGE_PAC_PAC_WATCHER
-                        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel8@sha256:0850f4dc229a01de74414fea9e30b864c994313d124818909c57a9f80fd50910
+                        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel8@sha256:614201024793b241fc2629f2ec73bd55d531059f5597e1b93711867591a2cd76
                       - name: IMAGE_RESULTS_WATCHER
-                        value: quay.io/openshift-pipeline/pipelines-results-watcher-rhel8@sha256:e8b5ba1b63bfef2b0bd93a22b3b69b03ef637dd7aa8e6b2709a7475b1e8b22f6
+                        value: quay.io/openshift-pipeline/pipelines-results-watcher-rhel8@sha256:edaee8ec21eb818fba63f6b3b2d2108ded923b960317ede11612f3ef2310a8ad
                       - name: IMAGE_RESULTS_API
-                        value: quay.io/openshift-pipeline/pipelines-results-api-rhel8@sha256:1490274ca62a7f91dd870247c2f6cf6659254c6b61939c44e3eeea12af707ce9
+                        value: quay.io/openshift-pipeline/pipelines-results-api-rhel8@sha256:0b6659cec2121c2b70c57aa57b90361a2ca1800516c87697af560902902e5a0b
                       - name: IMAGE_ADDONS_MAVEN_GOALS
                         value: registry.redhat.io/ubi8/openjdk-17@sha256:e8cc2e476282b75d89c73057bfa713db22d72bdb2808d62d981a84c33beb2575
                       - name: IMAGE_PIPELINES_CONSOLE_PLUGIN
-                        value: quay.io/openshift-pipeline/pipelines-console-plugin-rhel8@sha256:abc6499c29b8afce917c1295bab115b98b0267fbac7ad369760fabd4f3397de2
-                    image: quay.io/openshift-pipeline/pipelines-rhel8-operator@sha256:020b6739a6320b7c90e539fefde9e3f918f8629964781261a8e80bfae900f967
+                        value: quay.io/openshift-pipeline/pipelines-console-plugin-rhel8@sha256:df460a6665e01bfaa85a184437133126dc9b36bf6ae4efbeb0abc353cd4ab619
+                    image: quay.io/openshift-pipeline/pipelines-rhel8-operator@sha256:32ac7b5503e09b67af3bdb3be8cb6c3034ae62ba7b9a8078292648490fdf0176
                     imagePullPolicy: Always
                     name: openshift-pipelines-operator-lifecycle
                     resources: {}
@@ -1332,7 +1332,7 @@ spec:
                         value: tekton.dev/operator
                       - name: CONFIG_LEADERELECTION_NAME
                         value: tekton-operator-controller-config-leader-election
-                    image: quay.io/openshift-pipeline/pipelines-rhel8-operator@sha256:020b6739a6320b7c90e539fefde9e3f918f8629964781261a8e80bfae900f967
+                    image: quay.io/openshift-pipeline/pipelines-rhel8-operator@sha256:32ac7b5503e09b67af3bdb3be8cb6c3034ae62ba7b9a8078292648490fdf0176
                     imagePullPolicy: Always
                     name: openshift-pipelines-operator-cluster-operations
                     resources: {}
@@ -1386,7 +1386,7 @@ spec:
                         value: tekton.dev/operator
                       - name: PLATFORM
                         value: openshift
-                    image: quay.io/openshift-pipeline/pipelines-operator-webhook-rhel8@sha256:187488bbf30defcede9904a8f60205ee16e158dd46cd6b9349e09c0bfa7571d2
+                    image: quay.io/openshift-pipeline/pipelines-operator-webhook-rhel8@sha256:54b43aa3cb5cbdf8d7a270010a2abff0b258128839651ba5605e9397ebd88f4d
                     name: tekton-operator-webhook
                     ports:
                       - containerPort: 8443
@@ -1429,43 +1429,43 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-    - image: quay.io/openshift-pipeline/pipelines-rhel8-operator@sha256:020b6739a6320b7c90e539fefde9e3f918f8629964781261a8e80bfae900f967
+    - image: quay.io/openshift-pipeline/pipelines-rhel8-operator@sha256:32ac7b5503e09b67af3bdb3be8cb6c3034ae62ba7b9a8078292648490fdf0176
       name: OPENSHIFT_PIPELINES_OPERATOR_LIFECYCLE
-    - image: quay.io/openshift-pipeline/pipelines-rhel8-operator@sha256:020b6739a6320b7c90e539fefde9e3f918f8629964781261a8e80bfae900f967
+    - image: quay.io/openshift-pipeline/pipelines-rhel8-operator@sha256:32ac7b5503e09b67af3bdb3be8cb6c3034ae62ba7b9a8078292648490fdf0176
       name: OPENSHIFT_PIPELINES_OPERATOR_CLUSTER_OPERATIONS
-    - image: quay.io/openshift-pipeline/pipelines-operator-proxy-rhel8@sha256:0e2710179ec9b9d905593b4c180cad6d49dbeceb1b6a1930d9957ca32e1f9e3a
+    - image: quay.io/openshift-pipeline/pipelines-operator-proxy-rhel8@sha256:bc7afb441d2179f6ba40d44883d25ef7b80d2a4c12f4d8b7e9a6ea374e24e332
       name: IMAGE_PIPELINES_PROXY
-    - image: quay.io/openshift-pipeline/pipelines-controller-rhel8@sha256:94d5b387d143839d35b20e74a64531952c5651cf3b3916315b5510f06d1945a6
+    - image: quay.io/openshift-pipeline/pipelines-controller-rhel8@sha256:d3e64dc90eec6e54112aeb34f17e7155b9351c9850fae644725bd291be93d31c
       name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
-    - image: quay.io/openshift-pipeline/pipelines-webhook-rhel8@sha256:d2e8a562e8d8893917dcfac6380b248d2b195dffd898ded367f2f4e7620286d0
+    - image: quay.io/openshift-pipeline/pipelines-webhook-rhel8@sha256:f33e348c06ce4a91610958fb037457731a54f8b53a0b52f32f4e8484bfe4cd40
       name: IMAGE_PIPELINES_WEBHOOK
-    - image: quay.io/openshift-pipeline/pipelines-resolvers-rhel8@sha256:ab451765e0e07bb52be8fa66abb1045d5c7908abf4fc8c497df4afffd4be34d3
+    - image: quay.io/openshift-pipeline/pipelines-resolvers-rhel8@sha256:9fb0259ef015dba90afdf695c428bb0652f6f640d38cf801ba70b4c8f3e143d4
       name: IMAGE_PIPELINES_CONTROLLER
-    - image: quay.io/openshift-pipeline/pipelines-events-rhel8@sha256:3e31d38394e05559671bfef4dd8446d74e379389a30016d48cc4a0b22d45a775
+    - image: quay.io/openshift-pipeline/pipelines-events-rhel8@sha256:1bfab940282d8af8377a5cc34beb4ae18a027f971b80231f9382b3128772225c
       name: IMAGE_PIPELINES_TEKTON_EVENTS_CONTROLLER
-    - image: quay.io/openshift-pipeline/pipelines-entrypoint-rhel8@sha256:815e3f780e1b0171ede74a5ab974d360ab6542dd80fdafd3d03c836395b3d80c
+    - image: quay.io/openshift-pipeline/pipelines-entrypoint-rhel8@sha256:48ace5a1685b16f343378112a612f0c70a2fd4bbc5e3d5f558310dfc826430c8
       name: IMAGE_PIPELINES_ARG__ENTRYPOINT_IMAGE
-    - image: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:043080bff45cd129c0852b55a578c1a85e8911de80fadef22a21a034a1eccd56
+    - image: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:04f5c5f9b8a5e3642e4994790324c92c7ecb4a1562823d71254b60b7ebc671cb
       name: IMAGE_PIPELINES_ARG__GIT_IMAGE
-    - image: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:043080bff45cd129c0852b55a578c1a85e8911de80fadef22a21a034a1eccd56
+    - image: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:04f5c5f9b8a5e3642e4994790324c92c7ecb4a1562823d71254b60b7ebc671cb
       name: IMAGE_ADDONS_PARAM_GITINITIMAGE
-    - image: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:043080bff45cd129c0852b55a578c1a85e8911de80fadef22a21a034a1eccd56
+    - image: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:04f5c5f9b8a5e3642e4994790324c92c7ecb4a1562823d71254b60b7ebc671cb
       name: IMAGE_ADDONS_GIT_RUN
-    - image: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:043080bff45cd129c0852b55a578c1a85e8911de80fadef22a21a034a1eccd56
+    - image: quay.io/openshift-pipeline/pipelines-git-init-rhel8@sha256:04f5c5f9b8a5e3642e4994790324c92c7ecb4a1562823d71254b60b7ebc671cb
       name: IMAGE_ADDONS_REPORT
-    - image: quay.io/openshift-pipeline/pipelines-workingdirinit-rhel8@sha256:1a668bdf91a8127fde8c43593749f51ded53a0fbed551fab1c22b51483135205
+    - image: quay.io/openshift-pipeline/pipelines-workingdirinit-rhel8@sha256:69cb27dd7ddf41f054893b51f1bf5292c2711f1d0bec051d52febf77c37411ab
       name: IMAGE_PIPELINES_ARG__WORKINGDIRINIT_IMAGE
-    - image: quay.io/openshift-pipeline/pipelines-nop-rhel8@sha256:7c89565b0b580cfbdec22bdc5d6c6bc46af4512fd96ce8c49dc3dcad32273080
+    - image: quay.io/openshift-pipeline/pipelines-nop-rhel8@sha256:34ed012539ea11b008e1c0143a9e8ce1efbeccc7e54e20c2929e99993f5e94c9
       name: IMAGE_PIPELINES_ARG__NOP_IMAGE
-    - image: quay.io/openshift-pipeline/pipelines-entrypoint-rhel8@sha256:d7884d6fffd18f8810bf30798d057dac3c0366821a71e5dbe6ede14c0d11859b
+    - image: quay.io/openshift-pipeline/pipelines-entrypoint-rhel8@sha256:48ace5a1685b16f343378112a612f0c70a2fd4bbc5e3d5f558310dfc826430c8
       name: IMAGE_PIPELINES_ARG__SHELL_IMAGE
     - image: quay.io/openshift-pipeline/pipelines-triggers-controller-rhel8@sha256::81a78829a209a007182f0cd0002538fb1b5797c9877f7f4b6fa1289ba74d2698
       name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CONTROLLER
-    - image: quay.io/openshift-pipeline/pipelines-triggers-webhook-rhel8@sha256:387059126e53effe723c98f55fcc8ea1805919539e1e1841d09e96e306891cf9
+    - image: quay.io/openshift-pipeline/pipelines-triggers-webhook-rhel8@sha256:6d004404d43e31fc27be43f84ba1429e7ad2060c0d8c50a5d08296d1269b58b3
       name: IMAGE_TRIGGERS_WEBHOOK
-    - image: quay.io/openshift-pipeline/pipelines-triggers-core-interceptors-rhel8@sha256:3431fadcdb3d872b083df2a17ff083dcf6c90a13e5c6dd717d09072d2a37a041
+    - image: quay.io/openshift-pipeline/pipelines-triggers-core-interceptors-rhel8@sha256:e9417bd2679360504c31f26bdaf1b4b724716cacb4d7f0060282375fe4ab3161
       name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CORE_INTERCEPTORS
-    - image: quay.io/openshift-pipeline/pipelines-triggers-eventlistenersink-rhel8@sha256:9d0858b819cf2c739dd9783bd47c5f9e8df35c806b295ae62fbb985d52bf52b8
+    - image: quay.io/openshift-pipeline/pipelines-triggers-eventlistenersink-rhel8@sha256:0c5d68846bf897e3af5d7b147ed41448bdc99012b33df3662b54b361ff3b20c4
       name: IMAGE_TRIGGERS_ARG__EL_IMAGE
     - image: registry.redhat.io/openshift-serverless-1/client-kn-rhel8@sha256:bf6cf2e87fb19f7aa9a490b83c16af69834c0721220a643710a1b077959e91ca
       name: IMAGE_ADDONS_PARAM_KN_IMAGE
@@ -1495,47 +1495,47 @@ spec:
       name: IMAGE_ADDONS_MAVEN_GENERATE
     - image: registry.redhat.io/ubi8/ubi-minimal@sha256:f729a7f5685ea823e87ffd68aff988f2b8ff8d52126ade4e6de7c68088f28ebd
       name: IMAGE_ADDONS_PREPARE
-    - image: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:6bd9ec5e20d563207fd11de6d4609daacfc770d33b4b0b98c0bd7d9e6c6017b0
+    - image: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:3b4811317fd2c76d9fd403b2a499d90656423de571f785ee35da670f0fed8962
       name: IMAGE_JOB_PRUNER_TKN
-    - image: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:6bd9ec5e20d563207fd11de6d4609daacfc770d33b4b0b98c0bd7d9e6c6017b0
+    - image: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:3b4811317fd2c76d9fd403b2a499d90656423de571f785ee35da670f0fed8962
       name: IMAGE_ADDONS_PARAM_TKN_IMAGE
-    - image: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:6bd9ec5e20d563207fd11de6d4609daacfc770d33b4b0b98c0bd7d9e6c6017b0
+    - image: quay.io/openshift-pipeline/pipelines-cli-tkn-rhel8@sha256:3b4811317fd2c76d9fd403b2a499d90656423de571f785ee35da670f0fed8962
       name: IMAGE_ADDONS_TKN
-    - image: quay.io/openshift-pipeline/pipelines-serve-tkn-cli-rhel8@sha256:06a6c9d2f12f9446342c407e0ee6caa397d0ed4f6eefdd4c9c58f08fc98f62a5
+    - image: quay.io/openshift-pipeline/pipelines-serve-tkn-cli-rhel8@sha256:8eae5cd9e6cbd7a5956d2563112af9809c8482a2c5aba49bd9641aa3e50fb8cd
       name: IMAGE_ADDONS_TKN_CLI_SERVE
-    - image: quay.io/openshift-pipeline/pipelines-operator-webhook-rhel8@sha256:187488bbf30defcede9904a8f60205ee16e158dd46cd6b9349e09c0bfa7571d2
+    - image: quay.io/openshift-pipeline/pipelines-operator-webhook-rhel8@sha256:54b43aa3cb5cbdf8d7a270010a2abff0b258128839651ba5605e9397ebd88f4d
       name: TEKTON_OPERATOR_WEBHOOK
-    - image: quay.io/openshift-pipeline/pipelines-chains-controller-rhel8@sha256:fb31538fc07b36c9fc5064d7a3d4aeb1eed85aae7e340276d3f5de3f02c5985b
+    - image: quay.io/openshift-pipeline/pipelines-chains-controller-rhel8@sha256:0da4bbcaf1d77867eae57f1469a4ea32869a71d0d762130400df40e35d683945
       name: IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
     - image: registry.redhat.io/rhel8/postgresql-13@sha256:a92a579f1aef66ac188d24fd489c456a1a3e311d95dcce652da6b81e28fbf725
       name: IMAGE_HUB_TEKTON_HUB_DB
     - image: registry.redhat.io/rhel8/postgresql-13@sha256:a92a579f1aef66ac188d24fd489c456a1a3e311d95dcce652da6b81e28fbf725
       name: IMAGE_RESULTS_POSTGRES
-    - image: quay.io/openshift-pipeline/pipelines-hub-db-migration-rhel8@sha256:a803aca992f753d18e58c78f870b6e9c7b7a8d85ed042f74cdd27f22daf52d6d
+    - image: quay.io/openshift-pipeline/pipelines-hub-db-migration-rhel8@sha256:e9c37606a18e2f44487b1f68ffb12fa58fe2dc2d74bee7f71d17ce98aedfeee3
       name: IMAGE_HUB_TEKTON_HUB_DB_MIGRATION
-    - image: quay.io/openshift-pipeline/pipelines-hub-api-rhel8@sha256:241a99927f470f2ffd2cbdb6696e22a50192618d428e4d4a8a6b131cf81c9377
+    - image: quay.io/openshift-pipeline/pipelines-hub-api-rhel8@sha256:c8a83262ce2001d086d7ac9e8eb15112dbcae696ce16c950b9c0d7b683c4eb31
       name: IMAGE_HUB_TEKTON_HUB_API
-    - image: quay.io/openshift-pipeline/pipelines-hub-ui-rhel8@sha256:da30e1731eae77f655a60d18816b8afe837cd699f17c56621db5f681806cfdfd
+    - image: quay.io/openshift-pipeline/pipelines-hub-ui-rhel8@sha256:a8d7ab30b5f0dd0319dcbcafde2a6366bace47c6f87698d16c1270af420eb47b
       name: IMAGE_HUB_TEKTON_HUB_UI
-    - image: quay.io/openshift-pipeline/pipelines-manual-approval-gate-controller-rhel8@sha256:7c7c0414eaea222b247e3620a0162b94510296bd781401bcf7dfee1639d0e956
+    - image: quay.io/openshift-pipeline/pipelines-manual-approval-gate-controller-rhel8@sha256:9e01c4652508dd646568e646e45fd50a9c3ec846a2bececca1e26ea82aacbb22
       name: IMAGE_MAG_TEKTON_TASKGROUP_CONTROLLER
-    - image: quay.io/openshift-pipeline/pipelines-manual-approval-gate-webhook-rhel8@sha256:1dcf60ed244bc0d37b6472a3614e1d6c1a9ebe7ef1a06c492d5bde2eba2f4af0
+    - image: quay.io/openshift-pipeline/pipelines-manual-approval-gate-webhook-rhel8@sha256:700b8f1c84d23ff28cbcaa84bb3d00187d3fc4f88800d6ea4c239477dc41c3e2
       name: IMAGE_MAG_MANUAL_APPROVAL
-    - image: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel8@sha256:c7c216cb0ed3c163a4f9eeefd2bbbc20ebee28b8235eb51a9209443ba493f998
+    - image: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel8@sha256:66ca20713c84f4775a788d2839f0126ab4c149f62b9fe28fd4c694c941c22dfa
       name: IMAGE_PAC_PAC_CONTROLLER
-    - image: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel8@sha256:52825b01b2fea296caa58bea3e1195b1e40c1eaa5f6ae10192d2537897ca505c
+    - image: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel8@sha256:9e88266973bcdccc4e61d1dedc272704c3bd76a5d388d97c0ab325cc2431ac2b
       name: IMAGE_PAC_PAC_WEBHOOK
-    - image: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel8@sha256:0850f4dc229a01de74414fea9e30b864c994313d124818909c57a9f80fd50910
+    - image: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel8@sha256:614201024793b241fc2629f2ec73bd55d531059f5597e1b93711867591a2cd76
       name: IMAGE_PAC_PAC_WATCHER
-    - image: quay.io/openshift-pipeline/pipelines-results-watcher-rhel8@sha256:e8b5ba1b63bfef2b0bd93a22b3b69b03ef637dd7aa8e6b2709a7475b1e8b22f6
+    - image: quay.io/openshift-pipeline/pipelines-results-watcher-rhel8@sha256:edaee8ec21eb818fba63f6b3b2d2108ded923b960317ede11612f3ef2310a8ad
       name: IMAGE_RESULTS_WATCHER
-    - image: quay.io/openshift-pipeline/pipelines-results-api-rhel8@sha256:1490274ca62a7f91dd870247c2f6cf6659254c6b61939c44e3eeea12af707ce9
+    - image: quay.io/openshift-pipeline/pipelines-results-api-rhel8@sha256:0b6659cec2121c2b70c57aa57b90361a2ca1800516c87697af560902902e5a0b
       name: IMAGE_RESULTS_API
     - image: registry.redhat.io/ubi8/openjdk-17@sha256:e8cc2e476282b75d89c73057bfa713db22d72bdb2808d62d981a84c33beb2575
       name: IMAGE_ADDONS_PARAM_MAVEN_IMAGE
     - image: registry.redhat.io/ubi8/openjdk-17@sha256:e8cc2e476282b75d89c73057bfa713db22d72bdb2808d62d981a84c33beb2575
       name: IMAGE_ADDONS_MAVEN_GOALS
-    - image: quay.io/openshift-pipeline/pipelines-console-plugin-rhel8@sha256:abc6499c29b8afce917c1295bab115b98b0267fbac7ad369760fabd4f3397de2
+    - image: quay.io/openshift-pipeline/pipelines-console-plugin-rhel8@sha256:df460a6665e01bfaa85a184437133126dc9b36bf6ae4efbeb0abc353cd4ab619
       name: IMAGE_PIPELINES_CONSOLE_PLUGIN
   replaces: openshift-pipelines-operator-rh.v1.15.4
   version: 1.15.5


### PR DESCRIPTION
Consolidated nudge update — replaces 16 individual nudge PRs that conflicted after the first 3 merged.

Updates 28 image sha256 digests in the CSV from core snapshot `openshift-pipelines-core-1-15-20260722-115527-000-0e` (created 2026-07-22 17:35 IST).

Components not in CSV (expected): opc, pac-cli, sidecarlogresults, triggers-controller