### PR TITLE
[bot:1.23] Consolidated component nudge: operator, webhook, proxy, console-plugin

### DIFF
--- a/.konflux/olm-catalog/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/.konflux/olm-catalog/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -1325,7 +1325,7 @@ spec:
                       - name: OPERATOR_NAME
                         value: redhat-openshift-pipelines-operator
                       - name: IMAGE_PIPELINES_PROXY
-                        value: registry.stage.redhat.io/openshift-pipelines/pipelines-operator-proxy-rhel9@sha256:8379163ad0f8bb1cc5905943840e5b610da9491ce72bdc8ec568814e75788c45
+                        value: registry.stage.redhat.io/openshift-pipelines/pipelines-operator-proxy-rhel9@sha256:9f7dcb350cd38d3d3ec12bb759f654b2177040f4bc0c3dcd00fbe2d2b86b2a9f
                       - name: IMAGE_JOB_PRUNER_TKN
                         value: registry.stage.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:0f58a931756d6b68bb356f700679ff97a5fe7fda64960f0fba973519f246e61c
                       - name: METRICS_DOMAIN
@@ -1475,10 +1475,10 @@ spec:
                       - name: IMAGE_ADDONS_MAVEN_GOALS
                         value: registry.redhat.io/ubi9/openjdk-17@sha256:052c0ab499cfbb24b20339394778dfe6402a66b42398c8e59c87697b9b3f0a42
                       - name: IMAGE_PIPELINES_CONSOLE_PLUGIN
-                        value: registry.stage.redhat.io/openshift-pipelines/pipelines-console-plugin-rhel9@sha256:b7ba3e9bc22e3bdec60135b6504c64f6dd19db2b17de1b48bc8fc0035955c02f
+                        value: registry.stage.redhat.io/openshift-pipelines/pipelines-console-plugin-rhel9@sha256:2cd4fc0aadce80ac723dfaf7f4171f6a4dc0d7108b77adc9531e486a3c15ff31
                       - name: IMAGE_PIPELINES_CONSOLE_PLUGIN_LEGACY
                         value: registry.stage.redhat.io/openshift-pipelines/pipelines-console-plugin-pf5-rhel9@sha256:1480d6de425819d66355dd45abb941853824c3cb253553c1bc8f881cdb3ec2ea
-                    image: registry.stage.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:7b89fc8db424f4eef19e34f2629b00ff40c0967541786fd777e4368a6ee48f16
+                    image: registry.stage.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:bef6c7e320e28d12a729b8d7532091e152046dfd546ce049b54635f6c1db1d45
                     imagePullPolicy: Always
                     name: openshift-pipelines-operator-lifecycle
                     resources: {}
@@ -1516,7 +1516,7 @@ spec:
                         value: tekton.dev/operator
                       - name: CONFIG_LEADERELECTION_NAME
                         value: tekton-operator-controller-config-leader-election
-                    image: registry.stage.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:7b89fc8db424f4eef19e34f2629b00ff40c0967541786fd777e4368a6ee48f16
+                    image: registry.stage.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:bef6c7e320e28d12a729b8d7532091e152046dfd546ce049b54635f6c1db1d45
                     imagePullPolicy: Always
                     name: openshift-pipelines-operator-cluster-operations
                     resources: {}
@@ -1573,7 +1573,7 @@ spec:
                         value: tekton.dev/operator
                       - name: PLATFORM
                         value: openshift
-                    image: registry.stage.redhat.io/openshift-pipelines/pipelines-operator-webhook-rhel9@sha256:bbacc764cf342721d7781491a49c51da329ba5285c3c25a74ca9c15d0b97bd3c
+                    image: registry.stage.redhat.io/openshift-pipelines/pipelines-operator-webhook-rhel9@sha256:19b2ad4e715ce6175f5b815d5eb154ad670136cf73a051363c8983eda6186f69
                     name: tekton-operator-webhook
                     ports:
                       - containerPort: 8443
@@ -1622,11 +1622,11 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-    - image: registry.stage.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:7b89fc8db424f4eef19e34f2629b00ff40c0967541786fd777e4368a6ee48f16
+    - image: registry.stage.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:bef6c7e320e28d12a729b8d7532091e152046dfd546ce049b54635f6c1db1d45
       name: OPENSHIFT_PIPELINES_OPERATOR_LIFECYCLE
-    - image: registry.stage.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:7b89fc8db424f4eef19e34f2629b00ff40c0967541786fd777e4368a6ee48f16
+    - image: registry.stage.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:bef6c7e320e28d12a729b8d7532091e152046dfd546ce049b54635f6c1db1d45
       name: OPENSHIFT_PIPELINES_OPERATOR_CLUSTER_OPERATIONS
-    - image: registry.stage.redhat.io/openshift-pipelines/pipelines-operator-proxy-rhel9@sha256:8379163ad0f8bb1cc5905943840e5b610da9491ce72bdc8ec568814e75788c45
+    - image: registry.stage.redhat.io/openshift-pipelines/pipelines-operator-proxy-rhel9@sha256:9f7dcb350cd38d3d3ec12bb759f654b2177040f4bc0c3dcd00fbe2d2b86b2a9f
       name: IMAGE_PIPELINES_PROXY
     - image: registry.stage.redhat.io/openshift-pipelines/pipelines-controller-rhel9@sha256:ef244676680b440f7d8a08360b4c76f0d0df5d4e3ff20f2945c2e8c09020bcb0
       name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
@@ -1710,7 +1710,7 @@ spec:
       name: IMAGE_ADDONS_TKN_CLI_SERVE
     - image: registry.stage.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:f06aab36ccc4a9d0de6bbe13704c593f95fbf7b674d82ca17ea55eab3e277796
       name: IMAGE_ADDONS_TKN_CLI_SERVE_INIT_CONFIG
-    - image: registry.stage.redhat.io/openshift-pipelines/pipelines-operator-webhook-rhel9@sha256:bbacc764cf342721d7781491a49c51da329ba5285c3c25a74ca9c15d0b97bd3c
+    - image: registry.stage.redhat.io/openshift-pipelines/pipelines-operator-webhook-rhel9@sha256:19b2ad4e715ce6175f5b815d5eb154ad670136cf73a051363c8983eda6186f69
       name: TEKTON_OPERATOR_WEBHOOK
     - image: registry.stage.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel9@sha256:e968157a24dc75410f1576733d31edb3968274453e758258ebe3a4e875b02234
       name: IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
@@ -1758,7 +1758,7 @@ spec:
       name: IMAGE_ADDONS_PARAM_MAVEN_IMAGE
     - image: registry.redhat.io/ubi9/openjdk-17@sha256:052c0ab499cfbb24b20339394778dfe6402a66b42398c8e59c87697b9b3f0a42
       name: IMAGE_ADDONS_MAVEN_GOALS
-    - image: registry.stage.redhat.io/openshift-pipelines/pipelines-console-plugin-rhel9@sha256:b7ba3e9bc22e3bdec60135b6504c64f6dd19db2b17de1b48bc8fc0035955c02f
+    - image: registry.stage.redhat.io/openshift-pipelines/pipelines-console-plugin-rhel9@sha256:2cd4fc0aadce80ac723dfaf7f4171f6a4dc0d7108b77adc9531e486a3c15ff31
       name: IMAGE_PIPELINES_CONSOLE_PLUGIN
     - image: registry.stage.redhat.io/openshift-pipelines/pipelines-console-plugin-pf5-rhel9@sha256:1480d6de425819d66355dd45abb941853824c3cb253553c1bc8f881cdb3ec2ea
       name: IMAGE_PIPELINES_CONSOLE_PLUGIN_LEGACY

--- a/project.yaml
+++ b/project.yaml
@@ -79,13 +79,13 @@ images:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-pipelines-as-code-cli-rhel9@sha256:728366128f48b3c3d6a2e81b5b9117f1381231cd983761e5f4b7a328d1d9b35c
   # operator
   - name: OPENSHIFT_PIPELINES_OPERATOR_LIFECYCLE
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-rhel9-operator@sha256:7b89fc8db424f4eef19e34f2629b00ff40c0967541786fd777e4368a6ee48f16
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-rhel9-operator@sha256:bef6c7e320e28d12a729b8d7532091e152046dfd546ce049b54635f6c1db1d45
   - name: OPENSHIFT_PIPELINES_OPERATOR_CLUSTER_OPERATIONS
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-rhel9-operator@sha256:7b89fc8db424f4eef19e34f2629b00ff40c0967541786fd777e4368a6ee48f16
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-rhel9-operator@sha256:bef6c7e320e28d12a729b8d7532091e152046dfd546ce049b54635f6c1db1d45
   - name: IMAGE_PIPELINES_PROXY
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-operator-proxy-rhel9@sha256:8379163ad0f8bb1cc5905943840e5b610da9491ce72bdc8ec568814e75788c45
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-operator-proxy-rhel9@sha256:9f7dcb350cd38d3d3ec12bb759f654b2177040f4bc0c3dcd00fbe2d2b86b2a9f
   - name: TEKTON_OPERATOR_WEBHOOK
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-operator-webhook-rhel9@sha256:bbacc764cf342721d7781491a49c51da329ba5285c3c25a74ca9c15d0b97bd3c
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-operator-webhook-rhel9@sha256:19b2ad4e715ce6175f5b815d5eb154ad670136cf73a051363c8983eda6186f69
   # cache
   - name: IMAGE_ADDONS_CACHE_UPLOAD
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-cache-rhel9@sha256:7bb8fe54f93ee79513c07a44322f9714c9022f39c0610e77fe0210b39eae63e9
@@ -106,7 +106,7 @@ images:
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-git-init-rhel9@sha256:d8de2ba836fe94183804e10e122a9e19ff480a63be43feeaf3bc88d5f32c21cb
   # console-plugin
   - name: IMAGE_PIPELINES_CONSOLE_PLUGIN
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-console-plugin-rhel9@sha256:b7ba3e9bc22e3bdec60135b6504c64f6dd19db2b17de1b48bc8fc0035955c02f
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-console-plugin-rhel9@sha256:2cd4fc0aadce80ac723dfaf7f4171f6a4dc0d7108b77adc9531e486a3c15ff31
   - name: IMAGE_PIPELINES_CONSOLE_PLUGIN_LEGACY
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-console-plugin-pf5-rhel9@sha256:1480d6de425819d66355dd45abb941853824c3cb253553c1bc8f881cdb3ec2ea
   # OPC


### PR DESCRIPTION
Consolidates nudge PRs #26118, #26119, #26120, #26121 into a single conflict-free PR.

Updates SHA digests only — registry prefix (registry.stage.redhat.io) is preserved.

| Component | Old SHA | New SHA |
|-----------|---------|---------|
| pipelines-rhel9-operator | `7b89fc8` | `bef6c7e` |
| pipelines-operator-webhook-rhel9 | `bbacc76` | `19b2ad4` |
| pipelines-operator-proxy-rhel9 | `8379163` | `9f7dcb3` |
| pipelines-console-plugin-rhel9 | `b7ba3e9` | `2cd4fc0` |

Closes #26118, #26119, #26120, #26121