### PR TITLE
Add missing GitLab env vars to e2e task definition#

### DIFF
--- a/.konflux/tekton/task-e2e-pipeline.yaml
+++ b/.konflux/tekton/task-e2e-pipeline.yaml
@@ -121,6 +121,18 @@ spec:
               name: pac-gitlab
               key: gitlab-webhook-token
               optional: true
+        - name: GITLAB_GROUP_NAMESPACE
+          valueFrom:
+            secretKeyRef:
+              name: pac-gitlab
+              key: gitlab-group-ns
+              optional: true
+        - name: GITLAB_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: pac-gitlab
+              key: gitlab-project-id
+              optional: true
         - name: KUBECONFIG
           value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
         - name: CATALOG_SOURCE


### PR DESCRIPTION
GITLAB_GROUP_NAMESPACE and GITLAB_PROJECT_ID are required by SetupGitLabProject() but were not exposed in the task. Source both from the existing pac-gitlab secret.