### PR TITLE
Update CSV image digests to production references for 1.23.1

### DIFF
--- a/.konflux/olm-catalog/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/.konflux/olm-catalog/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -1327,7 +1327,7 @@ spec:
                       - name: IMAGE_PIPELINES_PROXY
                         value: registry.redhat.io/openshift-pipelines/pipelines-operator-proxy-rhel9@sha256:9f7dcb350cd38d3d3ec12bb759f654b2177040f4bc0c3dcd00fbe2d2b86b2a9f
                       - name: IMAGE_JOB_PRUNER_TKN
-                        value: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:0f58a931756d6b68bb356f700679ff97a5fe7fda64960f0fba973519f246e61c
+                        value: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:f61928b28ac959f291c5536e5a1ad9c1935a64f52516e59a58106e5d85fdad78
                       - name: METRICS_DOMAIN
                         value: tekton.dev/operator
                       - name: VERSION
@@ -1399,17 +1399,17 @@ spec:
                       - name: IMAGE_PIPELINES_ARG__SHELL_IMAGE
                         value: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel9@sha256:d3e77d0dbab84bdd2d901b7bf39c15f71b3e1d4b78d65e7dfab44ae4eb17adab
                       - name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CONTROLLER
-                        value: registry.redhat.io/openshift-pipelines/pipelines-triggers-controller-rhel9@sha256:7d4476c178490cf8aa0b84c5b1553cb94c7bbeff1d0b71b3b941123124196e34
+                        value: registry.redhat.io/openshift-pipelines/pipelines-triggers-controller-rhel9@sha256:f754bb12cf3829d50091271995bae2f0319a3b9feb794ba9d30a57c557c5994c
                       - name: IMAGE_TRIGGERS_WEBHOOK
-                        value: registry.redhat.io/openshift-pipelines/pipelines-triggers-webhook-rhel9@sha256:b84a4dcd371913fcad99eb2da8cf8ca1b14dd3b5090c94413d445059bdfbf6b3
+                        value: registry.redhat.io/openshift-pipelines/pipelines-triggers-webhook-rhel9@sha256:b362a215ccd00d35db0135cb4827d287b619523f356c5bf317e6e9abc63ac604
                       - name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CORE_INTERCEPTORS
-                        value: registry.redhat.io/openshift-pipelines/pipelines-triggers-core-interceptors-rhel9@sha256:71b82ae767caca6e78c05a3e6db4df985ad251e9c72aee27f6611f4cb75c3b84
+                        value: registry.redhat.io/openshift-pipelines/pipelines-triggers-core-interceptors-rhel9@sha256:d3a407eb9a950081d0ba2aca8a218778ffb7f3a764cb5d23de97f64efc7a42e0
                       - name: IMAGE_TRIGGERS_ARG__EL_IMAGE
-                        value: registry.redhat.io/openshift-pipelines/pipelines-triggers-eventlistenersink-rhel9@sha256:ec18ff5a5b70c026cf477d996ae515149f5194ebafe23e10777761f7330793ca
+                        value: registry.redhat.io/openshift-pipelines/pipelines-triggers-eventlistenersink-rhel9@sha256:38f9d862f7c7560cbc3aadc0cc919d17920daf8f6e9c9883cd3e0a4c64cdc7f3
                       - name: IMAGE_ADDONS_KN
                         value: registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel9@sha256:aee19896d17a431ba980564fdb73ef08ad1512f586fbdf954cecef6258f7a8df
                       - name: IMAGE_ADDONS_OPC
-                        value: registry.redhat.io/openshift-pipelines/pipelines-opc-rhel9@sha256:10204f46dd9bfbad2cfdf05d07e8729186e6c4ec0d6e50a59575a645b8fc51a0
+                        value: registry.redhat.io/openshift-pipelines/pipelines-opc-rhel9@sha256:5f8eb82ae49dfbf305d82d16c7dac11ae7fc234bfad4eab92b34e14e48b9ac79
                       - name: IMAGE_ADDONS_SKOPEO_RESULTS
                         value: registry.redhat.io/rhel9/skopeo@sha256:31839fd3e075e4d65a280a0c55da742bd3ceec5d92660ebab5423d3b9e84ad90
                       - name: IMAGE_ADDONS_BUILD
@@ -1425,9 +1425,9 @@ spec:
                       - name: IMAGE_ADDONS_PREPARE
                         value: registry.redhat.io/ubi9/ubi-minimal@sha256:6c79f4fb38a20d496c859025d57e4074835e849d5d14819c4e021ad78446bce8
                       - name: IMAGE_ADDONS_PARAM_TKN_IMAGE
-                        value: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:0f58a931756d6b68bb356f700679ff97a5fe7fda64960f0fba973519f246e61c
+                        value: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:f61928b28ac959f291c5536e5a1ad9c1935a64f52516e59a58106e5d85fdad78
                       - name: IMAGE_ADDONS_TKN
-                        value: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:0f58a931756d6b68bb356f700679ff97a5fe7fda64960f0fba973519f246e61c
+                        value: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:f61928b28ac959f291c5536e5a1ad9c1935a64f52516e59a58106e5d85fdad78
                       - name: IMAGE_ADDONS_TKN_CLI_SERVE
                         value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:f06aab36ccc4a9d0de6bbe13704c593f95fbf7b674d82ca17ea55eab3e277796
                       - name: IMAGE_ADDONS_TKN_CLI_SERVE_INIT_CONFIG
@@ -1437,17 +1437,17 @@ spec:
                       - name: IMAGE_RESULTS_POSTGRES
                         value: registry.redhat.io/rhel9/postgresql-15@sha256:1d4982f68db30af51a01b46c0bffcadcef26e13a634da5b74bb2fad7dfd8e2dc
                       - name: IMAGE_HUB_TEKTON_HUB_DB_MIGRATION
-                        value: registry.redhat.io/openshift-pipelines/pipelines-hub-db-migration-rhel9@sha256:5dd7ac07c7fe06ad1af7eed53753dff690ebdb09a4d1fd368d7485ee697846d2
+                        value: registry.redhat.io/openshift-pipelines/pipelines-hub-db-migration-rhel9@sha256:7726d044b733d16d0b6814858be1b53964a23a0e57d6c5abe9f09bf8938642d4
                       - name: IMAGE_HUB_TEKTON_HUB_API
-                        value: registry.redhat.io/openshift-pipelines/pipelines-hub-api-rhel9@sha256:0bffb5b0f70db7bd43beedaffb1d578a4164bb86b73296e0c6d685c9300c739d
+                        value: registry.redhat.io/openshift-pipelines/pipelines-hub-api-rhel9@sha256:ce3237feee02d4fc7d729fc6a63932ccd69c7b5c6c41ae7576997301c43efcfa
                       - name: IMAGE_HUB_TEKTON_HUB_UI
-                        value: registry.redhat.io/openshift-pipelines/pipelines-hub-ui-rhel9@sha256:78fdd883b915a91dc426966f9bc737f67fca34ef80be822487a9f8bdd64f3b63
+                        value: registry.redhat.io/openshift-pipelines/pipelines-hub-ui-rhel9@sha256:4d00b935f9447b13722102b70a6035f550ecd050ee5e60b8b3c773cb98209631
                       - name: IMAGE_MAG_TEKTON_TASKGROUP_CONTROLLER
                         value: registry.redhat.io/openshift-pipelines/pipelines-manual-approval-gate-controller-rhel9@sha256:6c7f1ac022c8e4d1139baa5685b34b66c248d3f1192a4a9ded69feb03ffa8e01
                       - name: IMAGE_MAG_MANUAL_APPROVAL
                         value: registry.redhat.io/openshift-pipelines/pipelines-manual-approval-gate-webhook-rhel9@sha256:ac12c8f59cd7b51739991cfc657f8f34ac555095db94058ee14e713de8899467
                       - name: IMAGE_PRUNER_CONTROLLER
-                        value: registry.redhat.io/openshift-pipelines/pipelines-pruner-controller-rhel9@sha256:a9fbaee59c8b371e6f376f5da432be960533a37f63138b704b21628c8556dc4e
+                        value: registry.redhat.io/openshift-pipelines/pipelines-pruner-controller-rhel9@sha256:edf3ecb4ec01bcbaeba97ddca85c690bee5842b88f63a9b843611cadb2f853e2
                       - name: IMAGE_SCHEDULER_MANAGER
                         value: registry.redhat.io/openshift-pipelines/pipelines-scheduler-rhel9@sha256:06e715c86acc5a0b850a605af887b42b35548a6b919459fa662d7f4d600c6060
                       - name: IMAGE_SCHEDULER_WEBHOOK
@@ -1457,7 +1457,7 @@ spec:
                       - name: IMAGE_SYNCER_SERVICE_WORKLOAD_CONTROLLER
                         value: registry.redhat.io/openshift-pipelines/pipelines-syncer-service-rhel9@sha256:e3ec04cb9835a5e696a03c8f26445fc0af78ab3d16d6429851e359f759c1925e
                       - name: IMAGE_PRUNER_WEBHOOK
-                        value: registry.redhat.io/openshift-pipelines/pipelines-pruner-webhook-rhel9@sha256:ab7af43ca4daa6b4716f2d9ec3fe0d537e276ff75225b70e8332d60bce2ca3bd
+                        value: registry.redhat.io/openshift-pipelines/pipelines-pruner-webhook-rhel9@sha256:5dbc260a4cbbd8c26d9211bd934998c4329eccac164481134a7400791dba4e58
                       - name: IMAGE_PAC_PAC_CONTROLLER
                         value: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-controller-rhel9@sha256:d05f9b871525678985b42e086c2683e698c57fd5fa59ac29387f6c143e6bd887
                       - name: IMAGE_PAC_PAC_WEBHOOK
@@ -1467,11 +1467,11 @@ spec:
                       - name: IMAGE_PAC_PAC_CLI
                         value: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-cli-rhel9@sha256:728366128f48b3c3d6a2e81b5b9117f1381231cd983761e5f4b7a328d1d9b35c
                       - name: IMAGE_RESULTS_WATCHER
-                        value: registry.redhat.io/openshift-pipelines/pipelines-results-watcher-rhel9@sha256:f420578aed6a3fca5aafb811a66322d062d6dbdb6943dc510cdf2dca72840e5c
+                        value: registry.redhat.io/openshift-pipelines/pipelines-results-watcher-rhel9@sha256:d1a9cf5ead984d6f1c9ccf50328b0932622e54e571ec6e0e12f70aa8127fe88a
                       - name: IMAGE_RESULTS_API
-                        value: registry.redhat.io/openshift-pipelines/pipelines-results-api-rhel9@sha256:f2394af8f50e1046179680187009e0d363ff9a734b8add6e9f36112058a1b1f8
+                        value: registry.redhat.io/openshift-pipelines/pipelines-results-api-rhel9@sha256:294d7bde082cb2c1506444e1a7908359c1d76ce0fdfdd0cef8763debc99114b2
                       - name: IMAGE_RESULTS_RETENTION_POLICY_AGENT
-                        value: registry.redhat.io/openshift-pipelines/pipelines-results-retention-policy-agent-rhel9@sha256:8ce4eba4025c458a1b048904ff6d4c08f0a15fc874381c03bc6d3d7d79e1ac05
+                        value: registry.redhat.io/openshift-pipelines/pipelines-results-retention-policy-agent-rhel9@sha256:92f6124fc728225467d9d1ce452d36e497e9a7d489252d9cf156eeac8b001b90
                       - name: IMAGE_ADDONS_MAVEN_GOALS
                         value: registry.redhat.io/ubi9/openjdk-17@sha256:052c0ab499cfbb24b20339394778dfe6402a66b42398c8e59c87697b9b3f0a42
                       - name: IMAGE_PIPELINES_CONSOLE_PLUGIN
@@ -1662,19 +1662,19 @@ spec:
       name: IMAGE_PIPELINES_ARG__NOP_IMAGE
     - image: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel9@sha256:d3e77d0dbab84bdd2d901b7bf39c15f71b3e1d4b78d65e7dfab44ae4eb17adab
       name: IMAGE_PIPELINES_ARG__SHELL_IMAGE
-    - image: registry.redhat.io/openshift-pipelines/pipelines-triggers-controller-rhel9@sha256:7d4476c178490cf8aa0b84c5b1553cb94c7bbeff1d0b71b3b941123124196e34
+    - image: registry.redhat.io/openshift-pipelines/pipelines-triggers-controller-rhel9@sha256:f754bb12cf3829d50091271995bae2f0319a3b9feb794ba9d30a57c557c5994c
       name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CONTROLLER
-    - image: registry.redhat.io/openshift-pipelines/pipelines-triggers-webhook-rhel9@sha256:b84a4dcd371913fcad99eb2da8cf8ca1b14dd3b5090c94413d445059bdfbf6b3
+    - image: registry.redhat.io/openshift-pipelines/pipelines-triggers-webhook-rhel9@sha256:b362a215ccd00d35db0135cb4827d287b619523f356c5bf317e6e9abc63ac604
       name: IMAGE_TRIGGERS_WEBHOOK
-    - image: registry.redhat.io/openshift-pipelines/pipelines-triggers-core-interceptors-rhel9@sha256:71b82ae767caca6e78c05a3e6db4df985ad251e9c72aee27f6611f4cb75c3b84
+    - image: registry.redhat.io/openshift-pipelines/pipelines-triggers-core-interceptors-rhel9@sha256:d3a407eb9a950081d0ba2aca8a218778ffb7f3a764cb5d23de97f64efc7a42e0
       name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CORE_INTERCEPTORS
-    - image: registry.redhat.io/openshift-pipelines/pipelines-triggers-eventlistenersink-rhel9@sha256:ec18ff5a5b70c026cf477d996ae515149f5194ebafe23e10777761f7330793ca
+    - image: registry.redhat.io/openshift-pipelines/pipelines-triggers-eventlistenersink-rhel9@sha256:38f9d862f7c7560cbc3aadc0cc919d17920daf8f6e9c9883cd3e0a4c64cdc7f3
       name: IMAGE_TRIGGERS_ARG__EL_IMAGE
     - image: registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel9@sha256:aee19896d17a431ba980564fdb73ef08ad1512f586fbdf954cecef6258f7a8df
       name: IMAGE_ADDONS_PARAM_KN_IMAGE
     - image: registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel9@sha256:aee19896d17a431ba980564fdb73ef08ad1512f586fbdf954cecef6258f7a8df
       name: IMAGE_ADDONS_KN
-    - image: registry.redhat.io/openshift-pipelines/pipelines-opc-rhel9@sha256:10204f46dd9bfbad2cfdf05d07e8729186e6c4ec0d6e50a59575a645b8fc51a0
+    - image: registry.redhat.io/openshift-pipelines/pipelines-opc-rhel9@sha256:5f8eb82ae49dfbf305d82d16c7dac11ae7fc234bfad4eab92b34e14e48b9ac79
       name: IMAGE_ADDONS_OPC
     - image: registry.redhat.io/rhel9/skopeo@sha256:31839fd3e075e4d65a280a0c55da742bd3ceec5d92660ebab5423d3b9e84ad90
       name: IMAGE_ADDONS_SKOPEO_COPY
@@ -1700,11 +1700,11 @@ spec:
       name: IMAGE_ADDONS_MAVEN_GENERATE
     - image: registry.redhat.io/ubi9/ubi-minimal@sha256:6c79f4fb38a20d496c859025d57e4074835e849d5d14819c4e021ad78446bce8
       name: IMAGE_ADDONS_PREPARE
-    - image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:0f58a931756d6b68bb356f700679ff97a5fe7fda64960f0fba973519f246e61c
+    - image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:f61928b28ac959f291c5536e5a1ad9c1935a64f52516e59a58106e5d85fdad78
       name: IMAGE_JOB_PRUNER_TKN
-    - image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:0f58a931756d6b68bb356f700679ff97a5fe7fda64960f0fba973519f246e61c
+    - image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:f61928b28ac959f291c5536e5a1ad9c1935a64f52516e59a58106e5d85fdad78
       name: IMAGE_ADDONS_PARAM_TKN_IMAGE
-    - image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:0f58a931756d6b68bb356f700679ff97a5fe7fda64960f0fba973519f246e61c
+    - image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:f61928b28ac959f291c5536e5a1ad9c1935a64f52516e59a58106e5d85fdad78
       name: IMAGE_ADDONS_TKN
     - image: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:f06aab36ccc4a9d0de6bbe13704c593f95fbf7b674d82ca17ea55eab3e277796
       name: IMAGE_ADDONS_TKN_CLI_SERVE
@@ -1718,17 +1718,17 @@ spec:
       name: IMAGE_HUB_TEKTON_HUB_DB
     - image: registry.redhat.io/rhel9/postgresql-15@sha256:1d4982f68db30af51a01b46c0bffcadcef26e13a634da5b74bb2fad7dfd8e2dc
       name: IMAGE_RESULTS_POSTGRES
-    - image: registry.redhat.io/openshift-pipelines/pipelines-hub-db-migration-rhel9@sha256:5dd7ac07c7fe06ad1af7eed53753dff690ebdb09a4d1fd368d7485ee697846d2
+    - image: registry.redhat.io/openshift-pipelines/pipelines-hub-db-migration-rhel9@sha256:7726d044b733d16d0b6814858be1b53964a23a0e57d6c5abe9f09bf8938642d4
       name: IMAGE_HUB_TEKTON_HUB_DB_MIGRATION
-    - image: registry.redhat.io/openshift-pipelines/pipelines-hub-api-rhel9@sha256:0bffb5b0f70db7bd43beedaffb1d578a4164bb86b73296e0c6d685c9300c739d
+    - image: registry.redhat.io/openshift-pipelines/pipelines-hub-api-rhel9@sha256:ce3237feee02d4fc7d729fc6a63932ccd69c7b5c6c41ae7576997301c43efcfa
       name: IMAGE_HUB_TEKTON_HUB_API
-    - image: registry.redhat.io/openshift-pipelines/pipelines-hub-ui-rhel9@sha256:78fdd883b915a91dc426966f9bc737f67fca34ef80be822487a9f8bdd64f3b63
+    - image: registry.redhat.io/openshift-pipelines/pipelines-hub-ui-rhel9@sha256:4d00b935f9447b13722102b70a6035f550ecd050ee5e60b8b3c773cb98209631
       name: IMAGE_HUB_TEKTON_HUB_UI
     - image: registry.redhat.io/openshift-pipelines/pipelines-manual-approval-gate-controller-rhel9@sha256:6c7f1ac022c8e4d1139baa5685b34b66c248d3f1192a4a9ded69feb03ffa8e01
       name: IMAGE_MAG_TEKTON_TASKGROUP_CONTROLLER
     - image: registry.redhat.io/openshift-pipelines/pipelines-manual-approval-gate-webhook-rhel9@sha256:ac12c8f59cd7b51739991cfc657f8f34ac555095db94058ee14e713de8899467
       name: IMAGE_MAG_MANUAL_APPROVAL
-    - image: registry.redhat.io/openshift-pipelines/pipelines-pruner-controller-rhel9@sha256:a9fbaee59c8b371e6f376f5da432be960533a37f63138b704b21628c8556dc4e
+    - image: registry.redhat.io/openshift-pipelines/pipelines-pruner-controller-rhel9@sha256:edf3ecb4ec01bcbaeba97ddca85c690bee5842b88f63a9b843611cadb2f853e2
       name: IMAGE_PRUNER_CONTROLLER
     - image: registry.redhat.io/openshift-pipelines/pipelines-scheduler-rhel9@sha256:06e715c86acc5a0b850a605af887b42b35548a6b919459fa662d7f4d600c6060
       name: IMAGE_SCHEDULER_MANAGER
@@ -1738,7 +1738,7 @@ spec:
       name: IMAGE_MULTICLUSTERPROXYAAE_PROXY_AAE
     - image: registry.redhat.io/openshift-pipelines/pipelines-syncer-service-rhel9@sha256:e3ec04cb9835a5e696a03c8f26445fc0af78ab3d16d6429851e359f759c1925e
       name: IMAGE_SYNCER_SERVICE_WORKLOAD_CONTROLLER
-    - image: registry.redhat.io/openshift-pipelines/pipelines-pruner-webhook-rhel9@sha256:ab7af43ca4daa6b4716f2d9ec3fe0d537e276ff75225b70e8332d60bce2ca3bd
+    - image: registry.redhat.io/openshift-pipelines/pipelines-pruner-webhook-rhel9@sha256:5dbc260a4cbbd8c26d9211bd934998c4329eccac164481134a7400791dba4e58
       name: IMAGE_PRUNER_WEBHOOK
     - image: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-controller-rhel9@sha256:d05f9b871525678985b42e086c2683e698c57fd5fa59ac29387f6c143e6bd887
       name: IMAGE_PAC_PAC_CONTROLLER
@@ -1748,11 +1748,11 @@ spec:
       name: IMAGE_PAC_PAC_WATCHER
     - image: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-cli-rhel9@sha256:728366128f48b3c3d6a2e81b5b9117f1381231cd983761e5f4b7a328d1d9b35c
       name: IMAGE_PAC_PAC_CLI
-    - image: registry.redhat.io/openshift-pipelines/pipelines-results-watcher-rhel9@sha256:f420578aed6a3fca5aafb811a66322d062d6dbdb6943dc510cdf2dca72840e5c
+    - image: registry.redhat.io/openshift-pipelines/pipelines-results-watcher-rhel9@sha256:d1a9cf5ead984d6f1c9ccf50328b0932622e54e571ec6e0e12f70aa8127fe88a
       name: IMAGE_RESULTS_WATCHER
-    - image: registry.redhat.io/openshift-pipelines/pipelines-results-api-rhel9@sha256:f2394af8f50e1046179680187009e0d363ff9a734b8add6e9f36112058a1b1f8
+    - image: registry.redhat.io/openshift-pipelines/pipelines-results-api-rhel9@sha256:294d7bde082cb2c1506444e1a7908359c1d76ce0fdfdd0cef8763debc99114b2
       name: IMAGE_RESULTS_API
-    - image: registry.redhat.io/openshift-pipelines/pipelines-results-retention-policy-agent-rhel9@sha256:8ce4eba4025c458a1b048904ff6d4c08f0a15fc874381c03bc6d3d7d79e1ac05
+    - image: registry.redhat.io/openshift-pipelines/pipelines-results-retention-policy-agent-rhel9@sha256:92f6124fc728225467d9d1ce452d36e497e9a7d489252d9cf156eeac8b001b90
       name: IMAGE_RESULTS_RETENTION_POLICY_AGENT
     - image: registry.redhat.io/ubi9/openjdk-17@sha256:052c0ab499cfbb24b20339394778dfe6402a66b42398c8e59c87697b9b3f0a42
       name: IMAGE_ADDONS_PARAM_MAVEN_IMAGE


### PR DESCRIPTION
## Summary

Replace 14 staging image digests in the Konflux OLM catalog CSV with production digests from core prod release `openshift-pipelines-core-1-23-prod-rp-zv8qb` (advisory [RHEA-2026](https://redhat.atlassian.net/browse/RHEA-2026):47223).

**Images updated:**
- triggers: controller, webhook, core-interceptors, eventlistenersink
- results: api, watcher, retention-policy-agent
- pruner: controller, webhook
- hub: api, db-migration, ui
- cli-tkn, opc

**Why:** Bundle prod release failed verify-conforma because the CSV referenced staging digests that don't exist at registry.redhat.io. The `operator-update-images` workflow was run incorrectly. This PR manually updates the digests using the production artifacts.

**After merge:** A new bundle-on-push build will produce a snapshot with the correct digests, unblocking the bundle prod release.