### PR TITLE
chore(deps): update console-plugin-pf5-1-22-console-plugin to d16e712

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -108,7 +108,7 @@ images:
   - name: IMAGE_PIPELINES_CONSOLE_PLUGIN
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-console-plugin-rhel9@sha256:42563898a5fe2604a13a1c936cc79e0383561decad76ebbbd338f16e4fe3f6a9
   - name: IMAGE_PIPELINES_CONSOLE_PLUGIN_LEGACY
-    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-console-plugin-pf5-rhel9@sha256:3296c9aab4701dda103d41d3b52a91084831fd3d5bfcd7eb736895e4614fad3c
+    value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-console-plugin-pf5-rhel9@sha256:d16e7127db81bf175e262325f50996f7fa9c34309905b531a807f795679a3ff6
   - name: IMAGE_ADDONS_OPC
     value: quay.io/redhat-user-workloads/tekton-ecosystem-tenant/pipelines-opc-rhel9@sha256:e308c565cb7e2c9f9eef58e8bfbf8eda018af748a3c8e92e95d3bbc33fee1347
   # Pruner


### PR DESCRIPTION
Manual nudge PR for console-plugin-pf5. The original nudge PR #26708 was closed due to merge conflicts.

Updates console-plugin-pf5 image SHA from `3296c9aa` to `d16e7127` in project.yaml to match the latest core snapshot.