### PR TITLE
fix(csv): update 18 image digests to match core snapshot v1.22.5

### DIFF
--- a/.konflux/olm-catalog/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
+++ b/.konflux/olm-catalog/bundle/manifests/openshift-pipelines-operator-rh.clusterserviceversion.yaml
@@ -1324,7 +1324,7 @@ spec:
                       - name: OPERATOR_NAME
                         value: redhat-openshift-pipelines-operator
                       - name: IMAGE_PIPELINES_PROXY
-                        value: registry.redhat.io/openshift-pipelines/pipelines-operator-proxy-rhel9@sha256:dd7a205a44f34be396115b28bf377a9e8d8ff2f1b5d0eb703df3529fd7fad27f
+                        value: registry.redhat.io/openshift-pipelines/pipelines-operator-proxy-rhel9@sha256:479f4afa02213f06105ab105125a9a5bc9c152172bee9dda27da421167d17d43
                       - name: IMAGE_JOB_PRUNER_TKN
                         value: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel9@sha256:b051b353f88732e0584afd991109d94a69417f6bd3eae6812117395e3f8c73b6
                       - name: METRICS_DOMAIN
@@ -1364,15 +1364,15 @@ spec:
                       - name: IMAGE_ADDONS_OC
                         value: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                       - name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
-                        value: registry.redhat.io/openshift-pipelines/pipelines-controller-rhel9@sha256:284c0136618ee72b3d0bfa3f2f59eb0632d2f6d261e754b565c36bade216d2b5
+                        value: registry.redhat.io/openshift-pipelines/pipelines-controller-rhel9@sha256:4aeb3322b2d728612be3010767188be459b7845f929192887236138a2f027c0f
                       - name: IMAGE_PIPELINES_WEBHOOK
-                        value: registry.redhat.io/openshift-pipelines/pipelines-webhook-rhel9@sha256:6fb0ef40cfccb23e2f4d6a63ce14b96aadac232fdb4756b5932a421533cb24c8
+                        value: registry.redhat.io/openshift-pipelines/pipelines-webhook-rhel9@sha256:f026e32a5e8c4755ea63690e9d5b85cb5077fdc5a18e97e9fe1d3ccbb6be0845
                       - name: IMAGE_PIPELINES_CONTROLLER
-                        value: registry.redhat.io/openshift-pipelines/pipelines-resolvers-rhel9@sha256:da5fa868bf4102780ccdd0a32b10e6cc4477c63c57f92c4f184845c080730694
+                        value: registry.redhat.io/openshift-pipelines/pipelines-resolvers-rhel9@sha256:793f68f20f76e1739862be29a6dcf83f3b3c70e775c196da6d51dd71744a2d97
                       - name: IMAGE_PIPELINES_TEKTON_EVENTS_CONTROLLER
-                        value: registry.redhat.io/openshift-pipelines/pipelines-events-rhel9@sha256:b4b08148dc641d0e05483886467a589a69aaa4e8828a9f6c18ffddc5268833a7
+                        value: registry.redhat.io/openshift-pipelines/pipelines-events-rhel9@sha256:99c4194267b388022ca470783c4ae46e5389345ae42be63d0bc05105a4bd911d
                       - name: IMAGE_PIPELINES_ARG__ENTRYPOINT_IMAGE
-                        value: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel9@sha256:981eec835cdf0181d0b9d9adc802a82758b6c426f9d592f07eea045e311a5710
+                        value: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel9@sha256:5bcaaba15e7a6115d82c3506420f238ee60b34ec4df6aeca9f7ba8da6b230531
                       - name: IMAGE_PIPELINES_ARG__GIT_IMAGE
                         value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:6ed2659105c59b326dd0e450c144578c0cae1ee23cb40e520eabe8817013a742
                       - name: IMAGE_ADDONS_PARAM_GITINITIMAGE
@@ -1390,13 +1390,13 @@ spec:
                       - name: IMAGE_ADDONS_CACHE_FETCH
                         value: registry.redhat.io/openshift-pipelines/pipelines-cache-rhel9@sha256:cbce8d9a3539e9767903ff9fec675afc3b6938a25fc43e8a0e55a92041a3c696
                       - name: IMAGE_PIPELINES_ARG__WORKINGDIRINIT_IMAGE
-                        value: registry.redhat.io/openshift-pipelines/pipelines-workingdirinit-rhel9@sha256:8dadfc889a318b37621bc2a49adb7c12a7a86e3828552b1da6976d315dde9e8e
+                        value: registry.redhat.io/openshift-pipelines/pipelines-workingdirinit-rhel9@sha256:220903349944999514e30a9f62c93035d615dd5a3b5d886f24b949fffd7e4fcb
                       - name: IMAGE_PIPELINES_ARG__SIDECARLOGRESULTS_IMAGE
-                        value: registry.redhat.io/openshift-pipelines/pipelines-sidecarlogresults-rhel9@sha256:25fe1c01f007918604918a9842c204272051aa9b9e72b6db2428626799c6ee21
+                        value: registry.redhat.io/openshift-pipelines/pipelines-sidecarlogresults-rhel9@sha256:41265d226a980a080731ded354dcb83853545d7d220fa916621cb5fa72e6e83c
                       - name: IMAGE_PIPELINES_ARG__NOP_IMAGE
-                        value: registry.redhat.io/openshift-pipelines/pipelines-nop-rhel9@sha256:3168dd512f78333f8eb6f5dc702bb98babee692972d472073e73fc94e4f49688
+                        value: registry.redhat.io/openshift-pipelines/pipelines-nop-rhel9@sha256:40a1f97dccab3a4ed8992b01b23a769c840ff7e7b770ca7fb240b0e9457b9046
                       - name: IMAGE_PIPELINES_ARG__SHELL_IMAGE
-                        value: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel9@sha256:981eec835cdf0181d0b9d9adc802a82758b6c426f9d592f07eea045e311a5710
+                        value: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel9@sha256:5bcaaba15e7a6115d82c3506420f238ee60b34ec4df6aeca9f7ba8da6b230531
                       - name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CONTROLLER
                         value: registry.redhat.io/openshift-pipelines/pipelines-triggers-controller-rhel9@sha256:0c174e1d15871eb22cb807450fdfc2b04d9167b7370b597b05c80f2c1d263e40
                       - name: IMAGE_TRIGGERS_WEBHOOK
@@ -1408,7 +1408,7 @@ spec:
                       - name: IMAGE_ADDONS_KN
                         value: registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel9@sha256:aee19896d17a431ba980564fdb73ef08ad1512f586fbdf954cecef6258f7a8df
                       - name: IMAGE_ADDONS_OPC
-                        value: registry.redhat.io/openshift-pipelines/pipelines-opc-rhel9@sha256:0e809e50b74d122c29f09af3266cba9310e78bb5402ea7718ae34573dd4e6f39
+                        value: registry.redhat.io/openshift-pipelines/pipelines-opc-rhel9@sha256:e308c565cb7e2c9f9eef58e8bfbf8eda018af748a3c8e92e95d3bbc33fee1347
                       - name: IMAGE_ADDONS_SKOPEO_RESULTS
                         value: registry.redhat.io/rhel9/skopeo@sha256:ff447341f85682ea35aa7903ae4da07033badc15b374353a65a1835bfc3c41e8
                       - name: IMAGE_ADDONS_BUILD
@@ -1432,7 +1432,7 @@ spec:
                       - name: IMAGE_ADDONS_TKN_CLI_SERVE_INIT_CONFIG
                         value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d6950bb05a6a1e33b9508be88b6ba15644fac15813c0ff91197d00d0b0695ac0
                       - name: IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
-                        value: registry.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel9@sha256:cc8d28c6eafd4a081fc5f2a0c4071852b5e8f7a634e22057fcaa9db255a935a8
+                        value: registry.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel9@sha256:114addf2eda4209e2b87a83835ee7ea6350209762277e5f0528a2c14e34c12ff
                       - name: IMAGE_RESULTS_POSTGRES
                         value: registry.redhat.io/rhel9/postgresql-15@sha256:868e460abe0655cee5818442f714f785e574a8fba9d026b8c791264362ca16a8
                       - name: IMAGE_HUB_TEKTON_HUB_DB_MIGRATION
@@ -1466,18 +1466,18 @@ spec:
                       - name: IMAGE_PAC_PAC_CLI
                         value: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-cli-rhel9@sha256:c386d232384e2fac3dbdcd871f9a362f80fc4d3f90e8255fb3edc9058da67054
                       - name: IMAGE_RESULTS_WATCHER
-                        value: registry.redhat.io/openshift-pipelines/pipelines-results-watcher-rhel9@sha256:ef26cc919a975c6f2efd7a566374e6e50961e858e5ea865fde5b4cfb66ce11d0
+                        value: registry.redhat.io/openshift-pipelines/pipelines-results-watcher-rhel9@sha256:db763bfae98190063718497efd8821dbe2f79197d0211084045d369cd1ab65f7
                       - name: IMAGE_RESULTS_API
-                        value: registry.redhat.io/openshift-pipelines/pipelines-results-api-rhel9@sha256:c1ef518d309bb77fdf8a048ad95d1663458c84f64a1dbe8a2ff521fe663b0d17
+                        value: registry.redhat.io/openshift-pipelines/pipelines-results-api-rhel9@sha256:2917fc8ef17f79f1d82fd997629add90d58c93769dbae1d07afffe9b98a85fab
                       - name: IMAGE_RESULTS_RETENTION_POLICY_AGENT
-                        value: registry.redhat.io/openshift-pipelines/pipelines-results-retention-policy-agent-rhel9@sha256:bc39d6e64f1ba3e42f36401ba9b62f93b7cd1910380cbfa3b3373038bd806069
+                        value: registry.redhat.io/openshift-pipelines/pipelines-results-retention-policy-agent-rhel9@sha256:cb6123e3655f21e1e00ae2e58bf10c9f9264bf1a43ac1c45bcd3f3d7be024b81
                       - name: IMAGE_ADDONS_MAVEN_GOALS
                         value: registry.redhat.io/ubi9/openjdk-17@sha256:052c0ab499cfbb24b20339394778dfe6402a66b42398c8e59c87697b9b3f0a42
                       - name: IMAGE_PIPELINES_CONSOLE_PLUGIN
-                        value: registry.redhat.io/openshift-pipelines/pipelines-console-plugin-rhel9@sha256:e4930187ac0130ff35348d7db1b60a44efc9aa450327776924f43fbc98236ecd
+                        value: registry.redhat.io/openshift-pipelines/pipelines-console-plugin-rhel9@sha256:42563898a5fe2604a13a1c936cc79e0383561decad76ebbbd338f16e4fe3f6a9
                       - name: IMAGE_PIPELINES_CONSOLE_PLUGIN_LEGACY
-                        value: registry.redhat.io/openshift-pipelines/pipelines-console-plugin-pf5-rhel9@sha256:ce81c0430a1695e5481c162d6e418dc7b22ac69ff6dd83669ccc6cf71bc329a6
-                    image: registry.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:c13f39db7d4bad8f6ced6accaab62eeb7cb0ea1752f48f1d75d61d35ebf4b8d5
+                        value: registry.redhat.io/openshift-pipelines/pipelines-console-plugin-pf5-rhel9@sha256:d16e7127db81bf175e262325f50996f7fa9c34309905b531a807f795679a3ff6
+                    image: registry.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:7fab5e1285be07866c7639bad42997fdf10a1cae4dbf5857a80f015d85449541
                     imagePullPolicy: Always
                     name: openshift-pipelines-operator-lifecycle
                     resources: {}
@@ -1515,7 +1515,7 @@ spec:
                         value: tekton.dev/operator
                       - name: CONFIG_LEADERELECTION_NAME
                         value: tekton-operator-controller-config-leader-election
-                    image: registry.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:c13f39db7d4bad8f6ced6accaab62eeb7cb0ea1752f48f1d75d61d35ebf4b8d5
+                    image: registry.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:7fab5e1285be07866c7639bad42997fdf10a1cae4dbf5857a80f015d85449541
                     imagePullPolicy: Always
                     name: openshift-pipelines-operator-cluster-operations
                     resources: {}
@@ -1572,7 +1572,7 @@ spec:
                         value: tekton.dev/operator
                       - name: PLATFORM
                         value: openshift
-                    image: registry.redhat.io/openshift-pipelines/pipelines-operator-webhook-rhel9@sha256:34d35e752236e09d56250f19a20ec7a88bbf967839ac6d3e59beb989f659e5af
+                    image: registry.redhat.io/openshift-pipelines/pipelines-operator-webhook-rhel9@sha256:eb9adb640a3ce4afc503f1e5914415a68b88bc680c9ffbd7b4d5401042a687c2
                     name: tekton-operator-webhook
                     ports:
                       - containerPort: 8443
@@ -1618,21 +1618,21 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-    - image: registry.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:c13f39db7d4bad8f6ced6accaab62eeb7cb0ea1752f48f1d75d61d35ebf4b8d5
+    - image: registry.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:7fab5e1285be07866c7639bad42997fdf10a1cae4dbf5857a80f015d85449541
       name: OPENSHIFT_PIPELINES_OPERATOR_LIFECYCLE
-    - image: registry.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:c13f39db7d4bad8f6ced6accaab62eeb7cb0ea1752f48f1d75d61d35ebf4b8d5
+    - image: registry.redhat.io/openshift-pipelines/pipelines-rhel9-operator@sha256:7fab5e1285be07866c7639bad42997fdf10a1cae4dbf5857a80f015d85449541
       name: OPENSHIFT_PIPELINES_OPERATOR_CLUSTER_OPERATIONS
-    - image: registry.redhat.io/openshift-pipelines/pipelines-operator-proxy-rhel9@sha256:dd7a205a44f34be396115b28bf377a9e8d8ff2f1b5d0eb703df3529fd7fad27f
+    - image: registry.redhat.io/openshift-pipelines/pipelines-operator-proxy-rhel9@sha256:479f4afa02213f06105ab105125a9a5bc9c152172bee9dda27da421167d17d43
       name: IMAGE_PIPELINES_PROXY
-    - image: registry.redhat.io/openshift-pipelines/pipelines-controller-rhel9@sha256:284c0136618ee72b3d0bfa3f2f59eb0632d2f6d261e754b565c36bade216d2b5
+    - image: registry.redhat.io/openshift-pipelines/pipelines-controller-rhel9@sha256:4aeb3322b2d728612be3010767188be459b7845f929192887236138a2f027c0f
       name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
-    - image: registry.redhat.io/openshift-pipelines/pipelines-webhook-rhel9@sha256:6fb0ef40cfccb23e2f4d6a63ce14b96aadac232fdb4756b5932a421533cb24c8
+    - image: registry.redhat.io/openshift-pipelines/pipelines-webhook-rhel9@sha256:f026e32a5e8c4755ea63690e9d5b85cb5077fdc5a18e97e9fe1d3ccbb6be0845
       name: IMAGE_PIPELINES_WEBHOOK
-    - image: registry.redhat.io/openshift-pipelines/pipelines-resolvers-rhel9@sha256:da5fa868bf4102780ccdd0a32b10e6cc4477c63c57f92c4f184845c080730694
+    - image: registry.redhat.io/openshift-pipelines/pipelines-resolvers-rhel9@sha256:793f68f20f76e1739862be29a6dcf83f3b3c70e775c196da6d51dd71744a2d97
       name: IMAGE_PIPELINES_CONTROLLER
-    - image: registry.redhat.io/openshift-pipelines/pipelines-events-rhel9@sha256:b4b08148dc641d0e05483886467a589a69aaa4e8828a9f6c18ffddc5268833a7
+    - image: registry.redhat.io/openshift-pipelines/pipelines-events-rhel9@sha256:99c4194267b388022ca470783c4ae46e5389345ae42be63d0bc05105a4bd911d
       name: IMAGE_PIPELINES_TEKTON_EVENTS_CONTROLLER
-    - image: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel9@sha256:981eec835cdf0181d0b9d9adc802a82758b6c426f9d592f07eea045e311a5710
+    - image: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel9@sha256:5bcaaba15e7a6115d82c3506420f238ee60b34ec4df6aeca9f7ba8da6b230531
       name: IMAGE_PIPELINES_ARG__ENTRYPOINT_IMAGE
     - image: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:6ed2659105c59b326dd0e450c144578c0cae1ee23cb40e520eabe8817013a742
       name: IMAGE_PIPELINES_ARG__GIT_IMAGE
@@ -1650,13 +1650,13 @@ spec:
       name: IMAGE_ADDONS_CACHE_UPLOAD
     - image: registry.redhat.io/openshift-pipelines/pipelines-cache-rhel9@sha256:cbce8d9a3539e9767903ff9fec675afc3b6938a25fc43e8a0e55a92041a3c696
       name: IMAGE_ADDONS_CACHE_FETCH
-    - image: registry.redhat.io/openshift-pipelines/pipelines-workingdirinit-rhel9@sha256:8dadfc889a318b37621bc2a49adb7c12a7a86e3828552b1da6976d315dde9e8e
+    - image: registry.redhat.io/openshift-pipelines/pipelines-workingdirinit-rhel9@sha256:220903349944999514e30a9f62c93035d615dd5a3b5d886f24b949fffd7e4fcb
       name: IMAGE_PIPELINES_ARG__WORKINGDIRINIT_IMAGE
-    - image: registry.redhat.io/openshift-pipelines/pipelines-sidecarlogresults-rhel9@sha256:25fe1c01f007918604918a9842c204272051aa9b9e72b6db2428626799c6ee21
+    - image: registry.redhat.io/openshift-pipelines/pipelines-sidecarlogresults-rhel9@sha256:41265d226a980a080731ded354dcb83853545d7d220fa916621cb5fa72e6e83c
       name: IMAGE_PIPELINES_ARG__SIDECARLOGRESULTS_IMAGE
-    - image: registry.redhat.io/openshift-pipelines/pipelines-nop-rhel9@sha256:3168dd512f78333f8eb6f5dc702bb98babee692972d472073e73fc94e4f49688
+    - image: registry.redhat.io/openshift-pipelines/pipelines-nop-rhel9@sha256:40a1f97dccab3a4ed8992b01b23a769c840ff7e7b770ca7fb240b0e9457b9046
       name: IMAGE_PIPELINES_ARG__NOP_IMAGE
-    - image: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel9@sha256:981eec835cdf0181d0b9d9adc802a82758b6c426f9d592f07eea045e311a5710
+    - image: registry.redhat.io/openshift-pipelines/pipelines-entrypoint-rhel9@sha256:5bcaaba15e7a6115d82c3506420f238ee60b34ec4df6aeca9f7ba8da6b230531
       name: IMAGE_PIPELINES_ARG__SHELL_IMAGE
     - image: registry.redhat.io/openshift-pipelines/pipelines-triggers-controller-rhel9@sha256:0c174e1d15871eb22cb807450fdfc2b04d9167b7370b597b05c80f2c1d263e40
       name: IMAGE_TRIGGERS_TEKTON_TRIGGERS_CONTROLLER
@@ -1670,7 +1670,7 @@ spec:
       name: IMAGE_ADDONS_PARAM_KN_IMAGE
     - image: registry.redhat.io/openshift-serverless-1/kn-client-kn-rhel9@sha256:aee19896d17a431ba980564fdb73ef08ad1512f586fbdf954cecef6258f7a8df
       name: IMAGE_ADDONS_KN
-    - image: registry.redhat.io/openshift-pipelines/pipelines-opc-rhel9@sha256:0e809e50b74d122c29f09af3266cba9310e78bb5402ea7718ae34573dd4e6f39
+    - image: registry.redhat.io/openshift-pipelines/pipelines-opc-rhel9@sha256:e308c565cb7e2c9f9eef58e8bfbf8eda018af748a3c8e92e95d3bbc33fee1347
       name: IMAGE_ADDONS_OPC
     - image: registry.redhat.io/rhel9/skopeo@sha256:ff447341f85682ea35aa7903ae4da07033badc15b374353a65a1835bfc3c41e8
       name: IMAGE_ADDONS_SKOPEO_COPY
@@ -1706,9 +1706,9 @@ spec:
       name: IMAGE_ADDONS_TKN_CLI_SERVE
     - image: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d6950bb05a6a1e33b9508be88b6ba15644fac15813c0ff91197d00d0b0695ac0
       name: IMAGE_ADDONS_TKN_CLI_SERVE_INIT_CONFIG
-    - image: registry.redhat.io/openshift-pipelines/pipelines-operator-webhook-rhel9@sha256:34d35e752236e09d56250f19a20ec7a88bbf967839ac6d3e59beb989f659e5af
+    - image: registry.redhat.io/openshift-pipelines/pipelines-operator-webhook-rhel9@sha256:eb9adb640a3ce4afc503f1e5914415a68b88bc680c9ffbd7b4d5401042a687c2
       name: TEKTON_OPERATOR_WEBHOOK
-    - image: registry.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel9@sha256:cc8d28c6eafd4a081fc5f2a0c4071852b5e8f7a634e22057fcaa9db255a935a8
+    - image: registry.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel9@sha256:114addf2eda4209e2b87a83835ee7ea6350209762277e5f0528a2c14e34c12ff
       name: IMAGE_CHAINS_TEKTON_CHAINS_CONTROLLER
     - image: registry.redhat.io/rhel9/postgresql-15@sha256:868e460abe0655cee5818442f714f785e574a8fba9d026b8c791264362ca16a8
       name: IMAGE_HUB_TEKTON_HUB_DB
@@ -1744,19 +1744,19 @@ spec:
       name: IMAGE_PAC_PAC_WATCHER
     - image: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-cli-rhel9@sha256:c386d232384e2fac3dbdcd871f9a362f80fc4d3f90e8255fb3edc9058da67054
       name: IMAGE_PAC_PAC_CLI
-    - image: registry.redhat.io/openshift-pipelines/pipelines-results-watcher-rhel9@sha256:ef26cc919a975c6f2efd7a566374e6e50961e858e5ea865fde5b4cfb66ce11d0
+    - image: registry.redhat.io/openshift-pipelines/pipelines-results-watcher-rhel9@sha256:db763bfae98190063718497efd8821dbe2f79197d0211084045d369cd1ab65f7
       name: IMAGE_RESULTS_WATCHER
-    - image: registry.redhat.io/openshift-pipelines/pipelines-results-api-rhel9@sha256:c1ef518d309bb77fdf8a048ad95d1663458c84f64a1dbe8a2ff521fe663b0d17
+    - image: registry.redhat.io/openshift-pipelines/pipelines-results-api-rhel9@sha256:2917fc8ef17f79f1d82fd997629add90d58c93769dbae1d07afffe9b98a85fab
       name: IMAGE_RESULTS_API
-    - image: registry.redhat.io/openshift-pipelines/pipelines-results-retention-policy-agent-rhel9@sha256:bc39d6e64f1ba3e42f36401ba9b62f93b7cd1910380cbfa3b3373038bd806069
+    - image: registry.redhat.io/openshift-pipelines/pipelines-results-retention-policy-agent-rhel9@sha256:cb6123e3655f21e1e00ae2e58bf10c9f9264bf1a43ac1c45bcd3f3d7be024b81
       name: IMAGE_RESULTS_RETENTION_POLICY_AGENT
     - image: registry.redhat.io/ubi9/openjdk-17@sha256:052c0ab499cfbb24b20339394778dfe6402a66b42398c8e59c87697b9b3f0a42
       name: IMAGE_ADDONS_PARAM_MAVEN_IMAGE
     - image: registry.redhat.io/ubi9/openjdk-17@sha256:052c0ab499cfbb24b20339394778dfe6402a66b42398c8e59c87697b9b3f0a42
       name: IMAGE_ADDONS_MAVEN_GOALS
-    - image: registry.redhat.io/openshift-pipelines/pipelines-console-plugin-rhel9@sha256:e4930187ac0130ff35348d7db1b60a44efc9aa450327776924f43fbc98236ecd
+    - image: registry.redhat.io/openshift-pipelines/pipelines-console-plugin-rhel9@sha256:42563898a5fe2604a13a1c936cc79e0383561decad76ebbbd338f16e4fe3f6a9
       name: IMAGE_PIPELINES_CONSOLE_PLUGIN
-    - image: registry.redhat.io/openshift-pipelines/pipelines-console-plugin-pf5-rhel9@sha256:ce81c0430a1695e5481c162d6e418dc7b22ac69ff6dd83669ccc6cf71bc329a6
+    - image: registry.redhat.io/openshift-pipelines/pipelines-console-plugin-pf5-rhel9@sha256:d16e7127db81bf175e262325f50996f7fa9c34309905b531a807f795679a3ff6
       name: IMAGE_PIPELINES_CONSOLE_PLUGIN_LEGACY
   replaces: openshift-pipelines-operator-rh.v1.22.4
   version: 1.22.5


### PR DESCRIPTION
## Summary

The `operator-update-images` workflow ([run](https://github.com/openshift-pipelines/operator/actions/runs/31036947053)) picked up stale `registry.redhat.io` digests from the previous release because it ran before the core prod release images had propagated. This caused the bundle prod release to fail Conforma's `olm.unmapped_references` check.

This PR replaces 18 stale image digests with the correct ones from core snapshot `openshift-pipelines-core-1-22-20260803-070817-000`.

### Changed images (18/40)
- pipelines-rhel9-operator
- pipelines-operator-proxy-rhel9
- pipelines-operator-webhook-rhel9
- pipelines-controller-rhel9
- pipelines-webhook-rhel9
- pipelines-resolvers-rhel9
- pipelines-events-rhel9
- pipelines-entrypoint-rhel9
- pipelines-workingdirinit-rhel9
- pipelines-sidecarlogresults-rhel9
- pipelines-nop-rhel9
- pipelines-opc-rhel9
- pipelines-chains-controller-rhel9
- pipelines-results-watcher-rhel9
- pipelines-results-api-rhel9
- pipelines-results-retention-policy-agent-rhel9
- pipelines-console-plugin-rhel9
- pipelines-console-plugin-pf5-rhel9

### Unchanged images (22/40)
Images that already had the correct digest from the current release were left as-is.

/approve
/lgtm